### PR TITLE
Finish repository and deployment setup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,9 @@ updates:
     directory: /
     schedule:
       interval: weekly
+      day: monday
+      time: "07:00"
+      timezone: Europe/Berlin
     groups:
       production-dependencies:
         dependency-type: production
@@ -16,8 +19,22 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      - dependency-name: "@types/node"
+        update-types:
+          - version-update:semver-major
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+      day: monday
+      time: "07:00"
+      timezone: Europe/Berlin
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -3,7 +3,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { GitFork, Moon, Sun } from "lucide-react";
+import { Moon, Sun } from "lucide-react";
 import { useTheme } from "next-themes";
 
 import { Button } from "@/components/ui/button";
@@ -19,6 +19,14 @@ const NAV_ITEMS = [
   { href: "/docs", label: "Docs" },
   { href: "/about", label: "About" },
 ] as const;
+
+function GitHubMark() {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M10.226 17.284c-2.965-.36-5.054-2.493-5.054-5.256 0-1.123.404-2.336 1.078-3.144-.292-.741-.247-2.314.09-2.965.898-.112 2.111.36 2.83 1.01.853-.269 1.752-.404 2.853-.404 1.1 0 1.999.135 2.807.382.696-.629 1.932-1.1 2.83-.988.315.606.36 2.179.067 2.942.72.854 1.101 2 1.101 3.167 0 2.763-2.089 4.852-5.098 5.234.763.494 1.28 1.572 1.28 2.807v2.336c0 .674.561 1.056 1.235.786 4.066-1.55 7.255-5.615 7.255-10.646C23.5 6.188 18.334 1 11.978 1 5.62 1 .5 6.188.5 12.545c0 4.986 3.167 9.12 7.435 10.669.606.225 1.19-.18 1.19-.786V20.63a2.9 2.9 0 0 1-1.078.224c-1.483 0-2.359-.808-2.987-2.313-.247-.607-.517-.966-1.034-1.033-.27-.023-.359-.135-.359-.27 0-.27.45-.471.898-.471.652 0 1.213.404 1.797 1.235.45.651.921.943 1.483.943.561 0 .92-.202 1.437-.719.382-.381.674-.718.944-.943" />
+    </svg>
+  );
+}
 
 export function SiteHeader() {
   const pathname = usePathname();
@@ -93,7 +101,7 @@ export function SiteHeader() {
               />
             }
           >
-            <GitFork />
+            <GitHubMark />
             <span className="sr-only">Open GitHub repository</span>
           </TooltipTrigger>
           <TooltipContent>GitHub repository</TooltipContent>

--- a/lib/site-config.ts
+++ b/lib/site-config.ts
@@ -1,4 +1,4 @@
 export const SITE_DESCRIPTION =
   "A private, local-first workspace for reviewing audio and editing transcripts side by side.";
 export const SITE_NAME = "Transcript Editor";
-export const SITE_URL = "https://transcript-edit.vercel.app";
+export const SITE_URL = "https://transcriptdesk.vercel.app";


### PR DESCRIPTION
## Summary

- use transcriptdesk.vercel.app as the canonical production URL
- replace the fork symbol with GitHub's official mark in the header
- run npm and GitHub Actions update checks at 07:00 Europe/Berlin every Monday
- group minor and patch dependency updates
- keep @types/node on the Node 24 major used by CI

## Related maintenance

- merged the green TypeScript 6 update in #19
- closed the Node 26 types update in #18 because the repository targets Node 24
- updated the GitHub repository homepage to transcriptdesk.vercel.app

## Validation

- pnpm lint
- pnpm typecheck