### PR TITLE
Add transcription workflow tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ A local-first transcription workspace with a waveform audio player on the left a
 
 ## Features
 
-- Local audio playback with a waveform, timeline, drag seeking, speed control, volume control, direct time entry, timestamp copying, drag-and-drop, and Media Session support.
-- CodeMirror 6 transcript editing with search, history, line wrapping, spellcheck, and timestamp insertion.
+- Local audio playback with a waveform, timeline, 1- and 5-second seeking, two-second resume rewind, speed control, volume control, direct time entry, timestamp copying, drag-and-drop, and Media Session support.
+- CodeMirror 6 transcript editing with search, undo and redo, line wrapping, spellcheck, timestamp insertion, and contextual timestamp-to-audio jumping.
 - TanStack Hotkeys shortcuts that keep the player usable while editing.
 - Responsive shadcn/Base UI interface with light and dark themes.
-- Browser-local transcript saving plus plain-text import and export without uploading files.
+- Browser-local transcript saving with 20 previous revisions, configurable speaker shortcuts, and plain-text import and export without uploading files.
 
 ## Stack
 

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -56,8 +56,8 @@ export default function AboutPage() {
               <h3 className="font-medium text-foreground">Audio player</h3>
               <ul className="mt-3 grid list-disc gap-1.5 pl-5">
                 <li>Displays a navigable waveform and timeline.</li>
-                <li>Supports play, pause, seeking, speed, and volume controls.</li>
-                <li>Copies or inserts the current playback timestamp.</li>
+                <li>Supports play, pause, precise seeking, resume rewind, speed, and volume controls.</li>
+                <li>Copies, inserts, and jumps to transcript timestamps.</li>
                 <li>Keeps audio files on the local device.</li>
               </ul>
             </div>
@@ -67,7 +67,8 @@ export default function AboutPage() {
                 <li>Creates, opens, renames, saves, and exports text files.</li>
                 <li>Provides line numbers, search and replace, undo, and redo.</li>
                 <li>Keeps the editor usable alongside playback shortcuts.</li>
-                <li>Stores saved drafts locally in the browser.</li>
+                <li>Stores the current transcript and 20 saved revisions locally.</li>
+                <li>Inserts locally configured speaker labels and shortcuts.</li>
               </ul>
             </div>
           </div>

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 
-import { Kbd } from "@/components/ui/kbd";
+import { ModifierKey, ShortcutKeys } from "@/components/shortcut-keys";
 
 export const metadata: Metadata = {
   title: "Docs",
@@ -14,27 +14,28 @@ const SHORTCUT_GROUPS = [
   {
     title: "Files",
     shortcuts: [
-      ["Open transcript", ["Ctrl / ⌘", "O"]],
-      ["Open audio", ["Ctrl / ⌘", "Shift", "O"]],
-      ["Save transcript locally", ["Ctrl / ⌘", "S"]],
-      ["Export text file", ["Ctrl / ⌘", "Shift", "S"]],
+      ["Open transcript", ["Mod", "O"]],
+      ["Open audio", ["Mod", "Shift", "O"]],
+      ["Save transcript locally", ["Mod", "S"]],
+      ["Export text file", ["Mod", "Shift", "S"]],
     ],
   },
   {
     title: "Playback",
     shortcuts: [
-      ["Play or pause", ["Ctrl / ⌘", "Enter"]],
-      ["Back five seconds", ["Ctrl / ⌘", "Shift", "←"]],
-      ["Forward five seconds", ["Ctrl / ⌘", "Shift", "→"]],
-      ["Insert timestamp", ["Ctrl / ⌘", "J"]],
+      ["Play or pause", ["Mod", "Enter"]],
+      ["Back five seconds", ["Mod", "Shift", "←"]],
+      ["Forward five seconds", ["Mod", "Shift", "→"]],
+      ["Insert timestamp", ["Mod", "J"]],
     ],
   },
   {
     title: "Editor",
     shortcuts: [
-      ["Find and replace", ["Ctrl / ⌘", "F"]],
-      ["Undo", ["Ctrl / ⌘", "Z"]],
-      ["Open documentation", ["Ctrl / ⌘", "/"]],
+      ["Find and replace", ["Mod", "F"]],
+      ["Undo", ["Mod", "Z"]],
+      ["Redo", ["Mod", "Y"], ["Mod", "Shift", "Z"]],
+      ["Open documentation", ["Mod", "/"]],
     ],
   },
 ] as const;
@@ -66,13 +67,11 @@ export default function DocsPage() {
               <div key={group.title}>
                 <h3 className="text-sm font-medium">{group.title}</h3>
                 <dl className="mt-3 grid gap-3">
-                  {group.shortcuts.map(([label, keys]) => (
+                  {group.shortcuts.map(([label, keys, macKeys]) => (
                     <div key={label} className="grid gap-1.5">
                       <dt className="text-xs text-muted-foreground">{label}</dt>
                       <dd className="flex flex-wrap items-center gap-1">
-                        {keys.map((key) => (
-                          <Kbd key={key}>{key}</Kbd>
-                        ))}
+                        <ShortcutKeys keys={keys} macKeys={macKeys} />
                       </dd>
                     </div>
                   ))}
@@ -80,6 +79,19 @@ export default function DocsPage() {
               </div>
             ))}
           </div>
+        </section>
+
+        <section aria-labelledby="editing-workflow">
+          <h2 id="editing-workflow" className="text-lg font-semibold">
+            Editing workflow
+          </h2>
+          <ul className="mt-4 grid list-disc gap-2 pl-5 text-sm leading-6 text-muted-foreground">
+            <li>Hover a timestamp or place the cursor inside it to reveal a jump action. <ModifierKey />-clicking the timestamp jumps immediately.</li>
+            <li>Find and replace opens from the transcript toolbar or its keyboard shortcut. Undo and redo work on individual editor changes.</li>
+            <li>Saving keeps the previous 20 local versions under Saved history.</li>
+            <li>Speaker text is inserted exactly as configured, with an optional shortcut set from the Speakers control in the transcript toolbar.</li>
+            <li>Playback resumes two seconds before the paused position. The transport controls provide separate 1- and 5-second jumps in both directions.</li>
+          </ul>
         </section>
 
         <section aria-labelledby="privacy">

--- a/app/globals.css
+++ b/app/globals.css
@@ -194,6 +194,187 @@
   background: color-mix(in oklab, var(--primary) 22%, transparent) !important;
 }
 
+.editor-shell .cm-tooltip:has(.cm-timestamp-jump-tooltip) {
+  overflow: visible;
+  border: 0;
+  background: transparent;
+}
+
+.cm-timestamp-jump-tooltip {
+  animation: timestamp-jump-in 120ms ease-out;
+}
+
+.cm-timestamp-jump-button {
+  display: inline-flex;
+  height: 1.75rem;
+  align-items: center;
+  gap: 0.55rem;
+  border: 1px solid color-mix(in oklab, var(--primary) 24%, var(--border));
+  border-radius: var(--radius-md);
+  background: var(--popover);
+  padding-inline: 0.6rem;
+  color: var(--popover-foreground);
+  font-family: var(--font-geist-sans), sans-serif;
+  font-size: 0.72rem;
+  font-weight: 500;
+  white-space: nowrap;
+  transition: background-color 120ms ease, border-color 120ms ease;
+}
+
+.editor-shell .cm-panels-top {
+  border-bottom: 0;
+}
+
+.editor-shell .cm-panel.cm-transcript-search {
+  position: relative;
+  display: grid;
+  gap: 0.45rem;
+  border-bottom: 1px solid var(--border);
+  background: var(--workspace-panel);
+  padding: 0.6rem;
+  color: var(--foreground);
+  font-family: var(--font-geist-sans), sans-serif;
+}
+
+.cm-transcript-search-row {
+  display: grid;
+  grid-template-columns: minmax(10rem, 1fr) auto repeat(6, 2rem);
+  gap: 0.35rem;
+  align-items: center;
+  padding-right: 2.35rem;
+}
+
+.cm-transcript-search-replace-row {
+  grid-template-columns: minmax(10rem, 1fr) auto auto;
+  padding-right: 2.35rem;
+}
+
+.cm-transcript-search-input {
+  height: 2rem;
+  min-width: 0;
+  border: 1px solid var(--input);
+  border-radius: var(--radius-md);
+  background: var(--background);
+  padding-inline: 0.65rem;
+  color: var(--foreground);
+  font: inherit;
+  font-size: 0.78rem;
+  outline: none;
+}
+
+.cm-transcript-search-input::placeholder {
+  color: var(--muted-foreground);
+}
+
+.cm-transcript-search-input:focus {
+  border-color: var(--ring);
+  box-shadow: 0 0 0 2px color-mix(in oklab, var(--ring) 24%, transparent);
+}
+
+.cm-transcript-search-status {
+  min-width: 5.25rem;
+  color: var(--muted-foreground);
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 0.65rem;
+  text-align: right;
+  white-space: nowrap;
+}
+
+.cm-transcript-search-button {
+  display: inline-grid;
+  min-width: 2rem;
+  height: 2rem;
+  cursor: pointer;
+  place-items: center;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--background);
+  padding-inline: 0.55rem;
+  color: var(--foreground);
+  font: inherit;
+  font-size: 0.72rem;
+  font-weight: 500;
+  white-space: nowrap;
+  transition: background-color 120ms ease, border-color 120ms ease, color 120ms ease;
+}
+
+.cm-transcript-search-button:hover:not(:disabled) {
+  border-color: color-mix(in oklab, var(--primary) 32%, var(--border));
+  background: var(--accent);
+}
+
+.cm-transcript-search-button[aria-pressed="true"] {
+  border-color: color-mix(in oklab, var(--primary) 45%, var(--border));
+  background: color-mix(in oklab, var(--primary) 12%, var(--background));
+  color: var(--primary);
+}
+
+.cm-transcript-search-button:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 1px;
+}
+
+.cm-transcript-search-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.cm-transcript-search-close {
+  position: absolute;
+  top: 0.6rem;
+  right: 0.6rem;
+  border-color: transparent;
+  background: transparent;
+  font-size: 1rem;
+}
+
+@media (max-width: 640px) {
+  .cm-transcript-search-row {
+    grid-template-columns: minmax(8rem, 1fr) repeat(3, 2rem);
+  }
+
+  .cm-transcript-search-status {
+    grid-column: 1;
+    grid-row: 2;
+    min-width: 0;
+    text-align: left;
+  }
+
+  .cm-transcript-search-replace-row {
+    grid-template-columns: minmax(8rem, 1fr) auto auto;
+    padding-right: 0;
+  }
+}
+
+.cm-timestamp-jump-button:hover {
+  border-color: color-mix(in oklab, var(--primary) 35%, var(--border));
+  background: var(--muted);
+}
+
+.cm-timestamp-jump-button:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+}
+
+.cm-timestamp-jump-shortcut {
+  color: var(--muted-foreground);
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 0.62rem;
+  font-weight: 400;
+}
+
+@keyframes timestamp-jump-in {
+  from {
+    opacity: 0;
+    transform: translateY(0.2rem) scale(0.98);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
 .waveform {
   background: color-mix(in oklab, var(--card) 65%, transparent);
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
 import { Geist, Geist_Mono } from "next/font/google";
+import Script from "next/script";
 
 import { ThemeProvider } from "@/components/theme-provider";
 import { SiteHeader } from "@/components/site-header";
@@ -9,6 +10,8 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { SITE_DESCRIPTION, SITE_NAME, SITE_URL } from "@/lib/site-config";
 
 import "./globals.css";
+
+const themeScript = `try{const stored=localStorage.getItem("theme");const dark=stored==="dark"||(stored!=="light"&&matchMedia("(prefers-color-scheme: dark)").matches);document.documentElement.classList.toggle("dark",dark);document.documentElement.style.colorScheme=dark?"dark":"light"}catch{}`;
 
 const geistSans = Geist({
   subsets: ["latin"],
@@ -81,12 +84,10 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       className={`${geistSans.variable} ${geistMono.variable}`}
     >
       <body className="min-h-dvh bg-background font-sans antialiased">
-        <ThemeProvider
-          attribute="class"
-          defaultTheme="system"
-          enableSystem
-          disableTransitionOnChange
-        >
+        <Script id="theme-initializer" strategy="beforeInteractive">
+          {themeScript}
+        </Script>
+        <ThemeProvider>
           <TooltipProvider delay={350}>
             <div className="flex min-h-dvh flex-col">
               <SiteHeader />

--- a/components/shortcut-keys.tsx
+++ b/components/shortcut-keys.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { Kbd } from "@/components/ui/kbd";
+import { useModifierKeyLabel } from "@/lib/platform";
+
+export function ModifierKey() {
+  return useModifierKeyLabel();
+}
+
+export function ShortcutKeys({ keys, macKeys }: { keys: readonly string[]; macKeys?: readonly string[] }) {
+  const modifierKey = useModifierKeyLabel();
+  const visibleKeys = modifierKey === "⌘" && macKeys ? macKeys : keys;
+
+  return visibleKeys.map((key) => <Kbd key={key}>{key === "Mod" ? modifierKey : key}</Kbd>);
+}

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -4,9 +4,9 @@ import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { Moon, Sun } from "lucide-react";
-import { useTheme } from "next-themes";
 
 import { Button } from "@/components/ui/button";
+import { useTheme } from "@/components/theme-provider";
 import {
   Tooltip,
   TooltipContent,
@@ -79,7 +79,8 @@ export function SiteHeader() {
               />
             }
           >
-            {resolvedTheme === "dark" ? <Sun /> : <Moon />}
+            <Moon className="dark:hidden" />
+            <Sun className="hidden dark:block" />
             <span className="sr-only">Toggle color theme</span>
           </TooltipTrigger>
           <TooltipContent>Toggle color theme</TooltipContent>

--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -1,8 +1,95 @@
 "use client";
 
-import type { ThemeProviderProps } from "next-themes";
-import { ThemeProvider as NextThemesProvider } from "next-themes";
+import { createContext, useContext, useMemo, useSyncExternalStore, type ReactNode } from "react";
 
-export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
-  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+type Theme = "dark" | "light" | "system";
+
+const STORAGE_KEY = "theme";
+const THEME_CHANGE_EVENT = "transcript-desk:theme-change";
+const SYSTEM_THEME_QUERY = "(prefers-color-scheme: dark)";
+
+type ThemeContextValue = {
+  resolvedTheme: "dark" | "light";
+  setTheme: (theme: Theme) => void;
+  theme: Theme;
+};
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+function getStoredTheme(): Theme {
+  try {
+    const theme = localStorage.getItem(STORAGE_KEY);
+    return theme === "dark" || theme === "light" ? theme : "system";
+  } catch {
+    return "system";
+  }
+}
+
+function getSystemTheme() {
+  return window.matchMedia(SYSTEM_THEME_QUERY).matches ? "dark" : "light";
+}
+
+function applyTheme(theme: Theme) {
+  const resolvedTheme = theme === "system" ? getSystemTheme() : theme;
+  document.documentElement.classList.toggle("dark", resolvedTheme === "dark");
+  document.documentElement.style.colorScheme = resolvedTheme;
+}
+
+function subscribeToTheme(onStoreChange: () => void) {
+  const handleChange = () => {
+    applyTheme(getStoredTheme());
+    onStoreChange();
+  };
+
+  window.addEventListener("storage", handleChange);
+  window.addEventListener(THEME_CHANGE_EVENT, handleChange);
+  return () => {
+    window.removeEventListener("storage", handleChange);
+    window.removeEventListener(THEME_CHANGE_EVENT, handleChange);
+  };
+}
+
+function subscribeToSystemTheme(onStoreChange: () => void) {
+  const mediaQuery = window.matchMedia(SYSTEM_THEME_QUERY);
+  const handleChange = () => {
+    if (getStoredTheme() === "system") {
+      applyTheme("system");
+    }
+    onStoreChange();
+  };
+
+  mediaQuery.addEventListener("change", handleChange);
+  return () => mediaQuery.removeEventListener("change", handleChange);
+}
+
+export function setTheme(theme: Theme) {
+  try {
+    if (theme === "system") {
+      localStorage.removeItem(STORAGE_KEY);
+    } else {
+      localStorage.setItem(STORAGE_KEY, theme);
+    }
+  } catch {
+    // The theme still changes for this page when storage is unavailable.
+  }
+
+  applyTheme(theme);
+  window.dispatchEvent(new Event(THEME_CHANGE_EVENT));
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error("useTheme must be used within ThemeProvider.");
+  }
+  return context;
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const theme = useSyncExternalStore(subscribeToTheme, getStoredTheme, () => "system" as const);
+  const systemTheme = useSyncExternalStore(subscribeToSystemTheme, getSystemTheme, () => "light" as const);
+  const resolvedTheme = theme === "system" ? systemTheme : theme;
+  const value = useMemo(() => ({ resolvedTheme, setTheme, theme }), [resolvedTheme, theme]);
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
 }

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -1,0 +1,160 @@
+"use client"
+
+import * as React from "react"
+import { Dialog as DialogPrimitive } from "@base-ui/react/dialog"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { XIcon } from "lucide-react"
+
+function Dialog({ ...props }: DialogPrimitive.Root.Props) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({ ...props }: DialogPrimitive.Trigger.Props) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({ ...props }: DialogPrimitive.Portal.Props) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({ ...props }: DialogPrimitive.Close.Props) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: DialogPrimitive.Backdrop.Props) {
+  return (
+    <DialogPrimitive.Backdrop
+      data-slot="dialog-overlay"
+      className={cn(
+        "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: DialogPrimitive.Popup.Props & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Popup
+        data-slot="dialog-content"
+        className={cn(
+          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            render={
+              <Button
+                variant="ghost"
+                className="absolute top-2 right-2"
+                size="icon-sm"
+              />
+            }
+          >
+            <XIcon
+            />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Popup>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({
+  className,
+  showCloseButton = false,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close render={<Button variant="outline" />}>
+          Close
+        </DialogPrimitive.Close>
+      )}
+    </div>
+  )
+}
+
+function DialogTitle({ className, ...props }: DialogPrimitive.Title.Props) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn(
+        "text-base leading-none font-medium",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: DialogPrimitive.Description.Props) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn(
+        "text-sm text-muted-foreground *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -1,0 +1,90 @@
+"use client"
+
+import * as React from "react"
+import { Popover as PopoverPrimitive } from "@base-ui/react/popover"
+
+import { cn } from "@/lib/utils"
+
+function Popover({ ...props }: PopoverPrimitive.Root.Props) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+}
+
+function PopoverTrigger({ ...props }: PopoverPrimitive.Trigger.Props) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+}
+
+function PopoverContent({
+  className,
+  align = "center",
+  alignOffset = 0,
+  side = "bottom",
+  sideOffset = 4,
+  ...props
+}: PopoverPrimitive.Popup.Props &
+  Pick<
+    PopoverPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset"
+  >) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Positioner
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+        className="isolate z-50"
+      >
+        <PopoverPrimitive.Popup
+          data-slot="popover-content"
+          className={cn(
+            "z-50 flex w-72 origin-(--transform-origin) flex-col gap-2.5 rounded-lg bg-popover p-2.5 text-sm text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-hidden duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            className
+          )}
+          {...props}
+        />
+      </PopoverPrimitive.Positioner>
+    </PopoverPrimitive.Portal>
+  )
+}
+
+function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="popover-header"
+      className={cn("flex flex-col gap-0.5 text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function PopoverTitle({ className, ...props }: PopoverPrimitive.Title.Props) {
+  return (
+    <PopoverPrimitive.Title
+      data-slot="popover-title"
+      className={cn("font-medium", className)}
+      {...props}
+    />
+  )
+}
+
+function PopoverDescription({
+  className,
+  ...props
+}: PopoverPrimitive.Description.Props) {
+  return (
+    <PopoverPrimitive.Description
+      data-slot="popover-description"
+      className={cn("text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Popover,
+  PopoverContent,
+  PopoverDescription,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverTrigger,
+}

--- a/components/ui/sonner.tsx
+++ b/components/ui/sonner.tsx
@@ -1,8 +1,9 @@
 "use client"
 
-import { useTheme } from "next-themes"
 import { Toaster as Sonner, type ToasterProps } from "sonner"
 import { CircleCheckIcon, InfoIcon, TriangleAlertIcon, OctagonXIcon, Loader2Icon } from "lucide-react"
+
+import { useTheme } from "@/components/theme-provider"
 
 const Toaster = ({ ...props }: ToasterProps) => {
   const { theme = "system" } = useTheme()

--- a/features/audio-player/audio-player.tsx
+++ b/features/audio-player/audio-player.tsx
@@ -8,8 +8,6 @@ import {
   LoaderCircle,
   Pause,
   Play,
-  RotateCcw,
-  RotateCw,
   Upload,
   Volume2,
   VolumeX,
@@ -42,6 +40,7 @@ export type AudioPlayerHandle = {
   getCurrentTime: () => number;
   openFilePicker: () => void;
   seekBy: (seconds: number) => void;
+  seekTo: (seconds: number) => void;
   togglePlayback: () => void;
 };
 
@@ -53,29 +52,83 @@ function formatFileSize(bytes: number) {
   return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
 }
 
+function SeekButton({ seconds, onSeek }: { seconds: -5 | -1 | 1 | 5; onSeek: () => void }) {
+  const direction = seconds < 0 ? "Back" : "Forward";
+  const amount = Math.abs(seconds);
+  const label = `${direction} ${amount} ${amount === 1 ? "second" : "seconds"}`;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <Button
+            variant="outline"
+            size="icon"
+            className="font-mono text-xs tabular-nums"
+            onClick={onSeek}
+          />
+        }
+      >
+        {seconds > 0 ? `+${seconds}` : `−${amount}`}
+        <span className="sr-only">{label}</span>
+      </TooltipTrigger>
+      <TooltipContent>{label}</TooltipContent>
+    </Tooltip>
+  );
+}
+
 export const AudioPlayer = forwardRef<AudioPlayerHandle>(
   function AudioPlayer(_, forwardedRef) {
-    const player = useAudioPlayer();
+    const {
+      beginEditingTime,
+      clearAudio,
+      copyTimestamp,
+      currentTime,
+      currentTimeRef,
+      duration,
+      error,
+      file,
+      fileInputRef,
+      isEditingTime,
+      isLoading,
+      isMuted,
+      isPlaying,
+      jumpToTimestamp,
+      jumpToTime,
+      openAudioFile,
+      playbackRate,
+      seekBy,
+      seekTo,
+      setTimeInput,
+      timeInput,
+      toggleMuted,
+      togglePlayback,
+      updatePlaybackRate,
+      updateVolume,
+      volume,
+      waveformRef,
+    } = useAudioPlayer();
 
     useImperativeHandle(
       forwardedRef,
       () => ({
-        getCurrentTime: () => player.currentTimeRef.current,
-        openFilePicker: () => player.fileInputRef.current?.click(),
-        seekBy: player.seekBy,
-        togglePlayback: player.togglePlayback,
+        getCurrentTime: () => currentTimeRef.current,
+        openFilePicker: () => fileInputRef.current?.click(),
+        seekBy,
+        seekTo: jumpToTimestamp,
+        togglePlayback,
       }),
-      [player.currentTimeRef, player.fileInputRef, player.seekBy, player.togglePlayback],
+      [currentTimeRef, fileInputRef, jumpToTimestamp, seekBy, togglePlayback],
     );
 
     return (
       <aside className="flex min-h-0 flex-col border-r bg-[var(--workspace-panel)] max-lg:border-r-0 max-lg:border-b">
         <input
-          ref={player.fileInputRef}
+          ref={fileInputRef}
           type="file"
           accept="audio/*,.aac,.aiff,.amr,.flac,.m4a,.mp3,.mp4,.ogg,.opus,.wav,.webm"
           className="sr-only"
-          onChange={(event) => player.openAudioFile(event.target.files?.[0])}
+          onChange={(event) => openAudioFile(event.target.files?.[0])}
         />
 
         <div className="flex h-12 shrink-0 items-center justify-between border-b px-3">
@@ -86,21 +139,21 @@ export const AudioPlayer = forwardRef<AudioPlayerHandle>(
               Local
             </Badge>
           </div>
-          <Button variant="outline" size="sm" onClick={() => player.fileInputRef.current?.click()}>
+          <Button variant="outline" size="sm" onClick={() => fileInputRef.current?.click()}>
             <Upload data-icon="inline-start" />
             Open
           </Button>
         </div>
 
-        {!player.file ? (
+        {!file ? (
           <button
             type="button"
             className="m-3 flex min-h-52 flex-col items-center justify-center gap-3 rounded-lg border border-dashed bg-card/70 px-6 text-center transition-colors hover:border-primary/40 hover:bg-card focus-visible:ring-3 focus-visible:ring-ring/40"
-            onClick={() => player.fileInputRef.current?.click()}
+            onClick={() => fileInputRef.current?.click()}
             onDragOver={(event) => event.preventDefault()}
             onDrop={(event) => {
               event.preventDefault();
-              player.openAudioFile(event.dataTransfer.files[0]);
+              openAudioFile(event.dataTransfer.files[0]);
             }}
           >
             <span className="grid size-10 place-items-center rounded-full border bg-background">
@@ -117,16 +170,16 @@ export const AudioPlayer = forwardRef<AudioPlayerHandle>(
           <div className="flex min-h-0 flex-1 flex-col">
             <div className="flex items-start justify-between gap-3 border-b bg-card/55 px-3 py-2.5">
               <div className="min-w-0">
-                <p className="truncate text-sm font-medium" title={player.file.name}>
-                  {player.file.name}
+                <p className="truncate text-sm font-medium" title={file.name}>
+                  {file.name}
                 </p>
                 <p className="mt-0.5 font-mono text-[0.68rem] text-muted-foreground">
-                  {formatFileSize(player.file.size)} · {formatTimestamp(player.duration)}
+                  {formatFileSize(file.size)} · {formatTimestamp(duration)}
                 </p>
               </div>
               <Tooltip>
                 <TooltipTrigger
-                  render={<Button variant="ghost" size="icon-sm" onClick={player.clearAudio} />}
+                  render={<Button variant="ghost" size="icon-sm" onClick={clearAudio} />}
                 >
                   <X />
                   <span className="sr-only">Close audio</span>
@@ -136,13 +189,13 @@ export const AudioPlayer = forwardRef<AudioPlayerHandle>(
             </div>
 
             <div className="px-3 pt-4">
-              <div ref={player.waveformRef} className="waveform min-h-28 overflow-hidden rounded-md" />
-              {player.error ? (
+              <div ref={waveformRef} className="waveform min-h-28 overflow-hidden rounded-md" />
+              {error ? (
                 <p
                   role="alert"
                   className="mt-2 rounded-md border border-destructive/30 bg-destructive/10 px-2.5 py-2 text-xs text-destructive"
                 >
-                  {player.error}
+                  {error}
                 </p>
               ) : null}
             </div>
@@ -150,56 +203,42 @@ export const AudioPlayer = forwardRef<AudioPlayerHandle>(
             <div className="px-3 py-4">
               <Slider
                 aria-label="Audio position"
-                value={[player.currentTime]}
+                value={[currentTime]}
                 min={0}
-                max={player.duration || 1}
+                max={duration || 1}
                 step={0.1}
                 onValueChange={(values) => {
                   const nextTime = Array.isArray(values) ? values[0] : values;
                   if (nextTime !== undefined) {
-                    player.seekTo(nextTime);
+                    seekTo(nextTime);
                   }
                 }}
               />
               <div className="mt-2 flex items-center justify-between font-mono text-[0.68rem] text-muted-foreground">
-                <span>{formatTimestamp(player.currentTime)}</span>
-                <span>-{formatTimestamp(Math.max(0, player.duration - player.currentTime))}</span>
+                <span>{formatTimestamp(currentTime)}</span>
+                <span>-{formatTimestamp(Math.max(0, duration - currentTime))}</span>
               </div>
             </div>
 
-            <div className="flex items-center justify-center gap-2 px-3 pb-4">
-              <Tooltip>
-                <TooltipTrigger
-                  render={<Button variant="outline" size="icon" onClick={() => player.seekBy(-5)} />}
-                >
-                  <RotateCcw />
-                  <span className="sr-only">Back five seconds</span>
-                </TooltipTrigger>
-                <TooltipContent>Back 5 seconds</TooltipContent>
-              </Tooltip>
+            <div className="flex items-center justify-center gap-1.5 px-3 pb-4">
+              <SeekButton seconds={-5} onSeek={() => seekBy(-5)} />
+              <SeekButton seconds={-1} onSeek={() => seekBy(-1)} />
               <Button
                 size="icon-lg"
-                className="size-11 rounded-full shadow-sm"
-                onClick={player.togglePlayback}
-                aria-label={player.isPlaying ? "Pause audio" : "Play audio"}
+                className="mx-0.5 size-11 rounded-full shadow-sm"
+                onClick={togglePlayback}
+                aria-label={isPlaying ? "Pause audio" : "Play audio"}
               >
-                {player.isLoading ? (
+                {isLoading ? (
                   <LoaderCircle className="animate-spin" />
-                ) : player.isPlaying ? (
+                ) : isPlaying ? (
                   <Pause className="fill-current" />
                 ) : (
                   <Play className="ml-0.5 fill-current" />
                 )}
               </Button>
-              <Tooltip>
-                <TooltipTrigger
-                  render={<Button variant="outline" size="icon" onClick={() => player.seekBy(5)} />}
-                >
-                  <RotateCw />
-                  <span className="sr-only">Forward five seconds</span>
-                </TooltipTrigger>
-                <TooltipContent>Forward 5 seconds</TooltipContent>
-              </Tooltip>
+              <SeekButton seconds={1} onSeek={() => seekBy(1)} />
+              <SeekButton seconds={5} onSeek={() => seekBy(5)} />
             </div>
 
             <Separator />
@@ -209,21 +248,21 @@ export const AudioPlayer = forwardRef<AudioPlayerHandle>(
                 className="flex items-center gap-2"
                 onSubmit={(event) => {
                   event.preventDefault();
-                  player.jumpToTime();
+                  jumpToTime();
                 }}
               >
                 <Input
                   aria-label="Jump to time"
                   value={
-                    player.isEditingTime
-                      ? player.timeInput
-                      : formatTimestamp(player.currentTime)
+                    isEditingTime
+                      ? timeInput
+                      : formatTimestamp(currentTime)
                   }
                   inputMode="numeric"
                   className="h-8 font-mono text-xs tabular-nums"
-                  onFocus={player.beginEditingTime}
-                  onBlur={player.jumpToTime}
-                  onChange={(event) => player.setTimeInput(event.target.value)}
+                  onFocus={beginEditingTime}
+                  onBlur={jumpToTime}
+                  onChange={(event) => setTimeInput(event.target.value)}
                 />
                 <Tooltip>
                   <TooltipTrigger
@@ -232,7 +271,7 @@ export const AudioPlayer = forwardRef<AudioPlayerHandle>(
                         type="button"
                         variant="outline"
                         size="icon"
-                        onClick={player.copyTimestamp}
+                        onClick={copyTimestamp}
                       />
                     }
                   >
@@ -249,8 +288,8 @@ export const AudioPlayer = forwardRef<AudioPlayerHandle>(
                   Speed
                 </div>
                 <Select
-                  value={player.playbackRate.toString()}
-                  onValueChange={player.updatePlaybackRate}
+                  value={playbackRate.toString()}
+                  onValueChange={updatePlaybackRate}
                 >
                   <SelectTrigger size="sm" className="w-24 font-mono">
                     <SelectValue />
@@ -269,21 +308,21 @@ export const AudioPlayer = forwardRef<AudioPlayerHandle>(
                 <Button
                   variant="ghost"
                   size="icon-sm"
-                  onClick={player.toggleMuted}
-                  aria-label={player.isMuted ? "Unmute audio" : "Mute audio"}
+                  onClick={toggleMuted}
+                  aria-label={isMuted ? "Unmute audio" : "Mute audio"}
                 >
-                  {player.isMuted || player.volume === 0 ? <VolumeX /> : <Volume2 />}
+                  {isMuted || volume === 0 ? <VolumeX /> : <Volume2 />}
                 </Button>
                 <Slider
                   aria-label="Audio volume"
-                  value={[player.isMuted ? 0 : player.volume]}
+                  value={[isMuted ? 0 : volume]}
                   min={0}
                   max={1}
                   step={0.01}
-                  onValueChange={player.updateVolume}
+                  onValueChange={updateVolume}
                 />
                 <span className="w-8 text-right font-mono text-[0.68rem] text-muted-foreground">
-                  {Math.round((player.isMuted ? 0 : player.volume) * 100)}
+                  {Math.round((isMuted ? 0 : volume) * 100)}
                 </span>
               </div>
             </div>

--- a/features/audio-player/use-audio-player.ts
+++ b/features/audio-player/use-audio-player.ts
@@ -1,15 +1,16 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { useTheme } from "next-themes";
 import { toast } from "sonner";
 import WaveSurfer from "wavesurfer.js";
 import Hover from "wavesurfer.js/dist/plugins/hover.esm.js";
 import Timeline from "wavesurfer.js/dist/plugins/timeline.esm.js";
 
+import { useTheme } from "@/components/theme-provider";
 import { clamp, formatTimestamp, parseTimestamp } from "@/lib/time-utils";
 
 const AUDIO_EXTENSION = /\.(aac|aiff|amr|flac|m4a|mp3|mp4|ogg|opus|wav|webm)$/i;
+const RESUME_REWIND_SECONDS = 2;
 const MEDIA_SESSION_ACTIONS = [
   "play",
   "pause",
@@ -56,6 +57,7 @@ export function useAudioPlayer() {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const isMutedRef = useRef(false);
   const playbackRateRef = useRef(1);
+  const resumeRewindPendingRef = useRef(false);
   const volumeRef = useRef(1);
   const waveformRef = useRef<HTMLDivElement>(null);
   const waveSurferRef = useRef<WaveSurfer | null>(null);
@@ -79,14 +81,43 @@ export function useAudioPlayer() {
     }
 
     const nextTime = clamp(seconds, 0, durationRef.current || 0);
+    resumeRewindPendingRef.current = false;
     audio.currentTime = nextTime;
     currentTimeRef.current = nextTime;
     setCurrentTime(nextTime);
   }, []);
 
+  const resumeAudio = useCallback((audio: HTMLAudioElement) => {
+    if (resumeRewindPendingRef.current) {
+      const nextTime = clamp(
+        audio.currentTime - RESUME_REWIND_SECONDS,
+        0,
+        audio.duration || 0,
+      );
+      audio.currentTime = nextTime;
+      currentTimeRef.current = nextTime;
+      setCurrentTime(nextTime);
+    }
+
+    resumeRewindPendingRef.current = false;
+    return audio.play();
+  }, []);
+
   const seekBy = useCallback(
     (seconds: number) => {
       seekTo(currentTimeRef.current + seconds);
+    },
+    [seekTo],
+  );
+
+  const jumpToTimestamp = useCallback(
+    (seconds: number) => {
+      if (!audioRef.current) {
+        toast.info("Open an audio file first.");
+        return;
+      }
+
+      seekTo(seconds);
     },
     [seekTo],
   );
@@ -100,13 +131,13 @@ export function useAudioPlayer() {
     }
 
     if (audio.paused) {
-      void audio.play().catch(() => {
+      void resumeAudio(audio).catch(() => {
         toast.error("The browser could not start audio playback.");
       });
     } else {
       audio.pause();
     }
-  }, []);
+  }, [resumeAudio]);
 
   useEffect(() => {
     if (!file || !waveformRef.current) {
@@ -152,8 +183,21 @@ export function useAudioPlayer() {
       currentTimeRef.current = audio.currentTime;
       setCurrentTime(audio.currentTime);
     };
-    const handlePlay = () => setIsPlaying(true);
-    const handlePause = () => setIsPlaying(false);
+    const handlePlay = () => {
+      resumeRewindPendingRef.current = false;
+      setIsPlaying(true);
+    };
+    const handlePause = () => {
+      resumeRewindPendingRef.current = audio.currentTime > 0 && !audio.ended;
+      setIsPlaying(false);
+    };
+    const handleEnded = () => {
+      resumeRewindPendingRef.current = false;
+      setIsPlaying(false);
+    };
+    const handleSeeking = () => {
+      resumeRewindPendingRef.current = false;
+    };
     const handleWaiting = () => setIsLoading(true);
     const handleCanPlay = () => setIsLoading(false);
     const handleError = () => {
@@ -166,7 +210,8 @@ export function useAudioPlayer() {
     audio.addEventListener("timeupdate", handleTimeUpdate);
     audio.addEventListener("play", handlePlay);
     audio.addEventListener("pause", handlePause);
-    audio.addEventListener("ended", handlePause);
+    audio.addEventListener("ended", handleEnded);
+    audio.addEventListener("seeking", handleSeeking);
     audio.addEventListener("waiting", handleWaiting);
     audio.addEventListener("canplay", handleCanPlay);
     audio.addEventListener("error", handleError);
@@ -182,7 +227,7 @@ export function useAudioPlayer() {
       }
 
       const handlers: Partial<Record<MediaSessionAction, MediaSessionActionHandler>> = {
-        play: () => void audio.play(),
+        play: () => void resumeAudio(audio),
         pause: () => audio.pause(),
         seekbackward: (details) => {
           audio.currentTime = clamp(
@@ -223,7 +268,8 @@ export function useAudioPlayer() {
       audio.removeEventListener("timeupdate", handleTimeUpdate);
       audio.removeEventListener("play", handlePlay);
       audio.removeEventListener("pause", handlePause);
-      audio.removeEventListener("ended", handlePause);
+      audio.removeEventListener("ended", handleEnded);
+      audio.removeEventListener("seeking", handleSeeking);
       audio.removeEventListener("waiting", handleWaiting);
       audio.removeEventListener("canplay", handleCanPlay);
       audio.removeEventListener("error", handleError);
@@ -233,7 +279,7 @@ export function useAudioPlayer() {
       URL.revokeObjectURL(objectUrl);
       clearMediaSession();
     };
-  }, [file]);
+  }, [file, resumeAudio]);
 
   useEffect(() => {
     const waveSurfer = waveSurferRef.current;
@@ -266,6 +312,7 @@ export function useAudioPlayer() {
     setDuration(0);
     durationRef.current = 0;
     setIsPlaying(false);
+    resumeRewindPendingRef.current = false;
     setError(null);
   };
 
@@ -276,6 +323,7 @@ export function useAudioPlayer() {
     setDuration(0);
     durationRef.current = 0;
     setIsPlaying(false);
+    resumeRewindPendingRef.current = false;
     setError(null);
     setTimeInput("00:00:00");
 
@@ -369,6 +417,7 @@ export function useAudioPlayer() {
     isLoading,
     isMuted,
     isPlaying,
+    jumpToTimestamp,
     jumpToTime,
     openAudioFile,
     playbackRate,

--- a/features/speakers/speaker-menu.tsx
+++ b/features/speakers/speaker-menu.tsx
@@ -1,0 +1,252 @@
+"use client";
+
+import { useState } from "react";
+import { Settings2, Trash2, UserRoundPlus, UsersRound } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Kbd } from "@/components/ui/kbd";
+import {
+  Popover,
+  PopoverContent,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  getSpeakerShortcutLabel,
+  isSpeakerShortcut,
+  SPEAKER_SHORTCUT_OPTIONS,
+  type SpeakerDefinition,
+} from "./speaker-settings-store";
+import { useModifierKeyLabel } from "@/lib/platform";
+
+type SpeakerMenuProps = {
+  disabled: boolean;
+  onChange: (speakers: SpeakerDefinition[]) => void;
+  onInsert: (speaker: SpeakerDefinition) => void;
+  speakers: SpeakerDefinition[];
+};
+
+function normalizeSpeakerName(name: string) {
+  return name.trim();
+}
+
+export function SpeakerMenu({ disabled, onChange, onInsert, speakers }: SpeakerMenuProps) {
+  const modifierKey = useModifierKeyLabel();
+  const alternateKey = modifierKey === "⌘" ? "Option" : "Alt";
+  const [draftSpeakers, setDraftSpeakers] = useState<SpeakerDefinition[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [popoverOpen, setPopoverOpen] = useState(false);
+  const [settingsOpen, setSettingsOpen] = useState(false);
+
+  const openSettings = () => {
+    const initialSpeakers = speakers.length
+      ? speakers.map((speaker) => ({ ...speaker }))
+      : [{ id: crypto.randomUUID(), name: "", shortcut: SPEAKER_SHORTCUT_OPTIONS[0]?.value ?? null }];
+    setDraftSpeakers(initialSpeakers);
+    setError(null);
+    setPopoverOpen(false);
+    setSettingsOpen(true);
+  };
+
+  const addSpeaker = () => {
+    const usedShortcuts = new Set(draftSpeakers.map((speaker) => speaker.shortcut));
+    const shortcut =
+      SPEAKER_SHORTCUT_OPTIONS.find((option) => !usedShortcuts.has(option.value))?.value ?? null;
+    setDraftSpeakers((current) => [
+      ...current,
+      { id: crypto.randomUUID(), name: "", shortcut },
+    ]);
+    setError(null);
+  };
+
+  const updateSpeaker = (id: string, update: Partial<SpeakerDefinition>) => {
+    setDraftSpeakers((current) =>
+      current.map((speaker) => (speaker.id === id ? { ...speaker, ...update } : speaker)),
+    );
+    setError(null);
+  };
+
+  const saveSettings = () => {
+    const normalizedSpeakers = draftSpeakers.map((speaker) => ({
+      ...speaker,
+      name: normalizeSpeakerName(speaker.name),
+    }));
+
+    if (normalizedSpeakers.some((speaker) => !speaker.name)) {
+      setError("Every speaker needs a name.");
+      return;
+    }
+
+    const normalizedNames = normalizedSpeakers.map((speaker) => speaker.name.toLocaleLowerCase());
+    if (new Set(normalizedNames).size !== normalizedNames.length) {
+      setError("Speaker names must be unique.");
+      return;
+    }
+
+    const shortcuts = normalizedSpeakers.flatMap((speaker) =>
+      speaker.shortcut ? [speaker.shortcut] : [],
+    );
+    if (new Set(shortcuts).size !== shortcuts.length) {
+      setError("Each shortcut can only be assigned once.");
+      return;
+    }
+
+    onChange(normalizedSpeakers);
+    setSettingsOpen(false);
+  };
+
+  return (
+    <>
+      <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
+        <PopoverTrigger
+          render={
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              disabled={disabled}
+              aria-label="Insert speaker"
+              title="Speakers"
+            />
+          }
+        >
+          <UsersRound />
+        </PopoverTrigger>
+        <PopoverContent align="end" className="w-72">
+          <PopoverHeader>
+            <PopoverTitle>Insert speaker</PopoverTitle>
+          </PopoverHeader>
+          {speakers.length ? (
+            <div className="grid gap-1">
+              {speakers.map((speaker) => {
+                const shortcutLabel = getSpeakerShortcutLabel(speaker.shortcut, modifierKey, alternateKey);
+                return (
+                  <Button
+                    key={speaker.id}
+                    variant="ghost"
+                    className="h-8 justify-between px-2 font-normal"
+                    onClick={() => {
+                      onInsert(speaker);
+                      setPopoverOpen(false);
+                    }}
+                  >
+                    <span className="truncate">{speaker.name}</span>
+                    {shortcutLabel ? <Kbd>{shortcutLabel}</Kbd> : null}
+                  </Button>
+                );
+              })}
+            </div>
+          ) : (
+            <p className="px-1 py-2 text-xs text-muted-foreground">No speakers configured.</p>
+          )}
+          <Button variant="outline" size="sm" className="justify-start" onClick={openSettings}>
+            <Settings2 data-icon="inline-start" />
+            Manage speakers
+          </Button>
+        </PopoverContent>
+      </Popover>
+
+      <Dialog open={settingsOpen} onOpenChange={setSettingsOpen}>
+        <DialogContent className="sm:max-w-xl">
+          <DialogHeader>
+            <DialogTitle>Speaker text and shortcuts</DialogTitle>
+            <DialogDescription>Configured text and shortcuts stay in this browser.</DialogDescription>
+          </DialogHeader>
+
+          <div className="grid max-h-[min(24rem,60vh)] gap-2 overflow-y-auto pr-1">
+            {draftSpeakers.map((speaker) => (
+              <div key={speaker.id} className="grid grid-cols-[minmax(0,1fr)_auto] gap-2 sm:grid-cols-[minmax(0,1fr)_10.5rem_auto]">
+                <Input
+                  aria-label="Speaker name"
+                  value={speaker.name}
+                  placeholder="Interviewer:"
+                  maxLength={60}
+                  onChange={(event) => updateSpeaker(speaker.id, { name: event.target.value })}
+                />
+                <Select
+                  value={speaker.shortcut ?? "none"}
+                  onValueChange={(value) =>
+                    updateSpeaker(speaker.id, {
+                      shortcut: value && isSpeakerShortcut(value) ? value : null,
+                    })
+                  }
+                >
+                  <SelectTrigger aria-label={`Shortcut for ${speaker.name || "speaker"}`} className="col-span-2 row-start-2 w-full sm:col-span-1 sm:col-start-2 sm:row-start-1">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="none">No shortcut</SelectItem>
+                    {SPEAKER_SHORTCUT_OPTIONS.map((option) => {
+                      const assignedElsewhere = draftSpeakers.some(
+                        (candidate) =>
+                          candidate.id !== speaker.id && candidate.shortcut === option.value,
+                      );
+                      return (
+                        <SelectItem key={option.value} value={option.value} disabled={assignedElsewhere}>
+                          {modifierKey} {alternateKey} {option.number}
+                        </SelectItem>
+                      );
+                    })}
+                  </SelectContent>
+                </Select>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  aria-label={`Remove ${speaker.name || "speaker"}`}
+                  onClick={() => {
+                    setDraftSpeakers((current) =>
+                      current.filter((candidate) => candidate.id !== speaker.id),
+                    );
+                    setError(null);
+                  }}
+                >
+                  <Trash2 />
+                </Button>
+              </div>
+            ))}
+          </div>
+
+          {error ? (
+            <p role="alert" className="text-xs text-destructive">
+              {error}
+            </p>
+          ) : null}
+
+          <Button
+            variant="outline"
+            size="sm"
+            className="w-fit"
+            disabled={draftSpeakers.length >= SPEAKER_SHORTCUT_OPTIONS.length}
+            onClick={addSpeaker}
+          >
+            <UserRoundPlus data-icon="inline-start" />
+            Add speaker
+          </Button>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setSettingsOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={saveSettings}>Save speakers</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/features/speakers/speaker-settings-store.ts
+++ b/features/speakers/speaker-settings-store.ts
@@ -1,0 +1,63 @@
+import "client-only";
+
+const STORAGE_KEY = "transcript-desk:speakers:v1";
+
+export type SpeakerShortcut = `Mod+Alt+${1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9}`;
+
+export const SPEAKER_SHORTCUT_OPTIONS = Array.from({ length: 9 }, (_, index) => {
+  const number = index + 1;
+  return {
+    number,
+    value: `Mod+Alt+${number}` as SpeakerShortcut,
+  };
+});
+
+export type SpeakerDefinition = {
+  id: string;
+  name: string;
+  shortcut: SpeakerShortcut | null;
+};
+
+export function isSpeakerShortcut(value: unknown): value is SpeakerShortcut {
+  return SPEAKER_SHORTCUT_OPTIONS.some((option) => option.value === value);
+}
+
+function isSpeakerDefinition(value: unknown): value is SpeakerDefinition {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const speaker = value as Partial<SpeakerDefinition>;
+  return (
+    typeof speaker.id === "string" &&
+    typeof speaker.name === "string" &&
+    (speaker.shortcut === null || isSpeakerShortcut(speaker.shortcut))
+  );
+}
+
+export function getSpeakerShortcutLabel(shortcut: string | null, modifierKey: string, alternateKey: string) {
+  const option = SPEAKER_SHORTCUT_OPTIONS.find((candidate) => candidate.value === shortcut);
+  return option ? `${modifierKey} ${alternateKey} ${option.number}` : null;
+}
+
+export function loadSpeakerSettings() {
+  try {
+    const storedValue = localStorage.getItem(STORAGE_KEY);
+    if (!storedValue) {
+      return [];
+    }
+
+    const parsedValue: unknown = JSON.parse(storedValue);
+    if (!Array.isArray(parsedValue)) {
+      return [];
+    }
+
+    return parsedValue.filter(isSpeakerDefinition).slice(0, SPEAKER_SHORTCUT_OPTIONS.length);
+  } catch {
+    return [];
+  }
+}
+
+export function saveSpeakerSettings(speakers: SpeakerDefinition[]) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(speakers));
+}

--- a/features/transcript-editor/search-panel.ts
+++ b/features/transcript-editor/search-panel.ts
@@ -1,0 +1,205 @@
+import {
+  closeSearchPanel,
+  findNext,
+  findPrevious,
+  getSearchQuery,
+  replaceAll,
+  replaceNext,
+  SearchQuery,
+  setSearchQuery,
+  selectMatches,
+} from "@codemirror/search";
+import type { EditorView, Panel, ViewUpdate } from "@codemirror/view";
+
+type QueryUpdate = Partial<
+  Pick<SearchQuery, "caseSensitive" | "regexp" | "replace" | "search" | "wholeWord">
+>;
+
+function updateSearchQuery(view: EditorView, update: QueryUpdate) {
+  const current = getSearchQuery(view.state);
+  view.dispatch({
+    effects: setSearchQuery.of(
+      new SearchQuery({
+        caseSensitive: update.caseSensitive ?? current.caseSensitive,
+        literal: current.literal,
+        regexp: update.regexp ?? current.regexp,
+        replace: update.replace ?? current.replace,
+        search: update.search ?? current.search,
+        wholeWord: update.wholeWord ?? current.wholeWord,
+      }),
+    ),
+  });
+}
+
+function createActionButton(label: string, text: string) {
+  const button = document.createElement("button");
+  button.type = "button";
+  button.className = "cm-transcript-search-button";
+  button.setAttribute("aria-label", label);
+  button.title = label;
+  button.textContent = text;
+  return button;
+}
+
+function getMatchStatus(view: EditorView, query: SearchQuery) {
+  if (!query.search) {
+    return "No query";
+  }
+
+  if (!query.valid) {
+    return "Invalid pattern";
+  }
+
+  const selection = view.state.selection.main;
+  const cursor = query.getCursor(view.state);
+  let currentMatch = 0;
+  let totalMatches = 0;
+  let truncated = false;
+
+  while (true) {
+    const result = cursor.next();
+    if (result.done) {
+      break;
+    }
+
+    totalMatches += 1;
+    if (result.value.from === selection.from && result.value.to === selection.to) {
+      currentMatch = totalMatches;
+    }
+
+    if (totalMatches === 1000) {
+      truncated = true;
+      break;
+    }
+  }
+
+  if (!totalMatches) {
+    return "No results";
+  }
+
+  if (truncated) {
+    return currentMatch ? `${currentMatch} / 1000+` : "1000+ results";
+  }
+
+  return currentMatch ? `${currentMatch} / ${totalMatches}` : `${totalMatches} result${totalMatches === 1 ? "" : "s"}`;
+}
+
+export function createTranscriptSearchPanel(view: EditorView): Panel {
+  const form = document.createElement("form");
+  const findRow = document.createElement("div");
+  const replaceRow = document.createElement("div");
+  const findInput = document.createElement("input");
+  const replaceInput = document.createElement("input");
+  const status = document.createElement("output");
+  const previousButton = createActionButton("Previous match", "↑");
+  const nextButton = createActionButton("Next match", "↓");
+  const selectAllButton = createActionButton("Select all matches", "All");
+  const caseButton = createActionButton("Match case", "Aa");
+  const wordButton = createActionButton("Match whole word", "W");
+  const regexpButton = createActionButton("Use regular expression", ".*");
+  const replaceButton = createActionButton("Replace current match", "Replace");
+  const replaceAllButton = createActionButton("Replace all matches", "Replace all");
+  const closeButton = createActionButton("Close search", "×");
+
+  form.className = "cm-transcript-search";
+  findRow.className = "cm-transcript-search-row";
+  replaceRow.className = "cm-transcript-search-row cm-transcript-search-replace-row";
+  findInput.className = "cm-transcript-search-input";
+  replaceInput.className = "cm-transcript-search-input";
+  status.className = "cm-transcript-search-status";
+  closeButton.classList.add("cm-transcript-search-close");
+  findInput.type = "search";
+  findInput.placeholder = "Find in transcript";
+  findInput.autocomplete = "off";
+  findInput.spellcheck = false;
+  findInput.setAttribute("aria-label", "Find in transcript");
+  findInput.setAttribute("main-field", "true");
+  replaceInput.type = "text";
+  replaceInput.placeholder = "Replace with";
+  replaceInput.autocomplete = "off";
+  replaceInput.spellcheck = false;
+  replaceInput.setAttribute("aria-label", "Replace with");
+  status.setAttribute("aria-live", "polite");
+  status.setAttribute("aria-atomic", "true");
+
+  const syncPanel = (editorView: EditorView) => {
+    const query = getSearchQuery(editorView.state);
+    findInput.value = query.search;
+    replaceInput.value = query.replace;
+    caseButton.setAttribute("aria-pressed", query.caseSensitive.toString());
+    wordButton.setAttribute("aria-pressed", query.wholeWord.toString());
+    regexpButton.setAttribute("aria-pressed", query.regexp.toString());
+    status.textContent = getMatchStatus(editorView, query);
+    const actionsDisabled = !query.valid;
+    previousButton.disabled = actionsDisabled;
+    nextButton.disabled = actionsDisabled;
+    selectAllButton.disabled = actionsDisabled;
+    replaceButton.disabled = actionsDisabled;
+    replaceAllButton.disabled = actionsDisabled;
+  };
+
+  findInput.addEventListener("input", () => updateSearchQuery(view, { search: findInput.value }));
+  replaceInput.addEventListener("input", () => updateSearchQuery(view, { replace: replaceInput.value }));
+  previousButton.addEventListener("click", () => findPrevious(view));
+  nextButton.addEventListener("click", () => findNext(view));
+  selectAllButton.addEventListener("click", () => selectMatches(view));
+  caseButton.addEventListener("click", () => {
+    const query = getSearchQuery(view.state);
+    updateSearchQuery(view, { caseSensitive: !query.caseSensitive });
+  });
+  wordButton.addEventListener("click", () => {
+    const query = getSearchQuery(view.state);
+    updateSearchQuery(view, { wholeWord: !query.wholeWord });
+  });
+  regexpButton.addEventListener("click", () => {
+    const query = getSearchQuery(view.state);
+    updateSearchQuery(view, { regexp: !query.regexp });
+  });
+  replaceButton.addEventListener("click", () => replaceNext(view));
+  replaceAllButton.addEventListener("click", () => replaceAll(view));
+  closeButton.addEventListener("click", () => {
+    closeSearchPanel(view);
+    view.focus();
+  });
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+    if (event instanceof SubmitEvent && event.submitter === previousButton) {
+      findPrevious(view);
+    } else {
+      findNext(view);
+    }
+  });
+  form.addEventListener("keydown", (event) => {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      closeSearchPanel(view);
+      view.focus();
+    } else if (event.key === "Enter" && (event.target === findInput || event.target === replaceInput)) {
+      event.preventDefault();
+      if (event.shiftKey) {
+        findPrevious(view);
+      } else {
+        findNext(view);
+      }
+    }
+  });
+
+  findRow.append(findInput, status, previousButton, nextButton, selectAllButton, caseButton, wordButton, regexpButton, closeButton);
+  replaceRow.append(replaceInput, replaceButton, replaceAllButton);
+  form.append(findRow, replaceRow);
+  syncPanel(view);
+
+  return {
+    dom: form,
+    top: true,
+    mount() {
+      findInput.focus();
+      findInput.select();
+    },
+    update(update: ViewUpdate) {
+      if (update.docChanged || update.selectionSet || update.transactions.some((transaction) => transaction.effects.length > 0)) {
+        syncPanel(update.view);
+      }
+    },
+  };
+}

--- a/features/transcript-editor/timestamp-jump-extension.ts
+++ b/features/transcript-editor/timestamp-jump-extension.ts
@@ -1,0 +1,128 @@
+import type { EditorState, Extension } from "@codemirror/state";
+import {
+  EditorView,
+  hoverTooltip,
+  showTooltip,
+  type Tooltip,
+} from "@codemirror/view";
+
+import { parseTimestamp } from "@/lib/time-utils";
+import { getModifierKeyLabel } from "@/lib/platform";
+
+const TIMESTAMP_PATTERN = /\[(\d{1,2}:[0-5]\d:[0-5]\d)\]/g;
+
+type TimestampMatch = {
+  from: number;
+  label: string;
+  seconds: number;
+  to: number;
+};
+
+function findTimestampAt(state: EditorState, position: number) {
+  const safePosition = Math.min(Math.max(position, 0), state.doc.length);
+  const line = state.doc.lineAt(safePosition);
+
+  TIMESTAMP_PATTERN.lastIndex = 0;
+  for (const match of line.text.matchAll(TIMESTAMP_PATTERN)) {
+    const index = match.index;
+    const label = match[1];
+
+    if (index === undefined || !label) {
+      continue;
+    }
+
+    const from = line.from + index;
+    const to = from + match[0].length;
+
+    if (safePosition < from || safePosition > to) {
+      continue;
+    }
+
+    const seconds = parseTimestamp(label);
+    if (seconds === null) {
+      return null;
+    }
+
+    return { from, label, seconds, to } satisfies TimestampMatch;
+  }
+
+  return null;
+}
+
+function createJumpTooltip(
+  match: TimestampMatch,
+  onJumpToTime: (seconds: number) => void,
+): Tooltip {
+  return {
+    pos: match.from,
+    end: match.to,
+    above: true,
+    arrow: false,
+    create: () => {
+      const dom = document.createElement("div");
+      const button = document.createElement("button");
+      const shortcut = document.createElement("span");
+
+      dom.className = "cm-timestamp-jump-tooltip";
+      button.type = "button";
+      button.className = "cm-timestamp-jump-button";
+      button.textContent = `Jump to ${match.label}`;
+      button.setAttribute("aria-label", `Jump audio to ${match.label}`);
+      shortcut.className = "cm-timestamp-jump-shortcut";
+      shortcut.textContent = `${getModifierKeyLabel()} click`;
+      button.append(shortcut);
+      button.addEventListener("mousedown", (event) => event.preventDefault());
+      button.addEventListener("click", () => onJumpToTime(match.seconds));
+      dom.append(button);
+
+      return { dom };
+    },
+  };
+}
+
+export function timestampJumpExtension(onJumpToTime: (seconds: number) => void): Extension {
+  const cursorTooltip = showTooltip.compute(["selection", "doc"], (state) => {
+    const selection = state.selection.main;
+    if (!selection.empty) {
+      return null;
+    }
+
+    const match = findTimestampAt(state, selection.head);
+    return match ? createJumpTooltip(match, onJumpToTime) : null;
+  });
+
+  const hover = hoverTooltip(
+    (view, position) => {
+      const cursorMatch = findTimestampAt(view.state, view.state.selection.main.head);
+      const match = findTimestampAt(view.state, position);
+
+      if (!match || (cursorMatch && cursorMatch.from === match.from)) {
+        return null;
+      }
+
+      return createJumpTooltip(match, onJumpToTime);
+    },
+    { hoverTime: 180, hideOnChange: true },
+  );
+
+  const modifierClick = EditorView.domEventHandlers({
+    mousedown(event, view) {
+      if (event.button !== 0 || (!event.ctrlKey && !event.metaKey)) {
+        return false;
+      }
+
+      const position = view.posAtCoords({ x: event.clientX, y: event.clientY });
+      const match = position === null ? null : findTimestampAt(view.state, position);
+
+      if (!match) {
+        return false;
+      }
+
+      event.preventDefault();
+      onJumpToTime(match.seconds);
+      return true;
+    },
+  });
+
+  return [cursorTooltip, hover, modifierClick];
+}

--- a/features/transcript-editor/transcript-editor.tsx
+++ b/features/transcript-editor/transcript-editor.tsx
@@ -6,32 +6,66 @@ import {
   useImperativeHandle,
   useRef,
 } from "react";
+import {
+  redo as redoCommand,
+  redoDepth,
+  undo as undoCommand,
+  undoDepth,
+} from "@codemirror/commands";
+import { openSearchPanel, search } from "@codemirror/search";
 import { basicSetup } from "codemirror";
 import { EditorView, placeholder } from "@codemirror/view";
 
+import { timestampJumpExtension } from "./timestamp-jump-extension";
+import { createTranscriptSearchPanel } from "./search-panel";
+
+export type EditorHistoryState = {
+  canRedo: boolean;
+  canUndo: boolean;
+};
+
 export type TranscriptEditorHandle = {
   focus: () => void;
+  insertSpeaker: (name: string) => void;
   insertText: (text: string) => void;
+  openSearch: () => void;
+  redo: () => void;
+  undo: () => void;
 };
 
 type TranscriptEditorProps = {
   value: string;
+  onHistoryStateChange: (state: EditorHistoryState) => void;
   onChange: (value: string) => void;
+  onJumpToTime: (seconds: number) => void;
 };
 
 export const TranscriptEditor = forwardRef<
   TranscriptEditorHandle,
   TranscriptEditorProps
->(function TranscriptEditor({ value, onChange }, forwardedRef) {
+>(function TranscriptEditor(
+  { value, onChange, onHistoryStateChange, onJumpToTime },
+  forwardedRef,
+) {
   const containerRef = useRef<HTMLDivElement>(null);
   const editorRef = useRef<EditorView | null>(null);
   const onChangeRef = useRef(onChange);
+  const onHistoryStateChangeRef = useRef(onHistoryStateChange);
+  const onJumpToTimeRef = useRef(onJumpToTime);
   const initialValueRef = useRef(value);
   const externalUpdateRef = useRef(false);
 
   useEffect(() => {
     onChangeRef.current = onChange;
   }, [onChange]);
+
+  useEffect(() => {
+    onHistoryStateChangeRef.current = onHistoryStateChange;
+  }, [onHistoryStateChange]);
+
+  useEffect(() => {
+    onJumpToTimeRef.current = onJumpToTime;
+  }, [onJumpToTime]);
 
   useEffect(() => {
     if (!containerRef.current) {
@@ -49,9 +83,18 @@ export const TranscriptEditor = forwardRef<
           spellcheck: "true",
         }),
         placeholder("Start typing or open a .txt transcript…"),
+        search({ createPanel: createTranscriptSearchPanel, top: true }),
+        timestampJumpExtension((seconds) => onJumpToTimeRef.current(seconds)),
         EditorView.updateListener.of((update) => {
           if (update.docChanged && !externalUpdateRef.current) {
             onChangeRef.current(update.state.doc.toString());
+          }
+
+          if (update.docChanged || update.transactions.some((transaction) => transaction.selection)) {
+            onHistoryStateChangeRef.current({
+              canRedo: redoDepth(update.state) > 0,
+              canUndo: undoDepth(update.state) > 0,
+            });
           }
         }),
         EditorView.theme({
@@ -64,6 +107,7 @@ export const TranscriptEditor = forwardRef<
     });
 
     editorRef.current = editor;
+    onHistoryStateChangeRef.current({ canRedo: false, canUndo: false });
 
     return () => {
       editor.destroy();
@@ -92,6 +136,26 @@ export const TranscriptEditor = forwardRef<
       focus() {
         editorRef.current?.focus();
       },
+      insertSpeaker(name: string) {
+        const editor = editorRef.current;
+
+        if (!editor) {
+          return;
+        }
+
+        const selection = editor.state.selection.main;
+        const line = editor.state.doc.lineAt(selection.from);
+        const lineIsEmpty = line.text.trim().length === 0;
+        const text = `${lineIsEmpty ? "" : "\n"}${name}`;
+        const from = lineIsEmpty ? line.from : selection.from;
+        const to = lineIsEmpty ? line.to : selection.to;
+        editor.dispatch({
+          changes: { from, to, insert: text },
+          selection: { anchor: from + text.length },
+          scrollIntoView: true,
+        });
+        editor.focus();
+      },
       insertText(text: string) {
         const editor = editorRef.current;
 
@@ -106,6 +170,26 @@ export const TranscriptEditor = forwardRef<
           scrollIntoView: true,
         });
         editor.focus();
+      },
+      openSearch() {
+        const editor = editorRef.current;
+        if (editor) {
+          openSearchPanel(editor);
+        }
+      },
+      redo() {
+        const editor = editorRef.current;
+        if (editor) {
+          redoCommand(editor);
+          editor.focus();
+        }
+      },
+      undo() {
+        const editor = editorRef.current;
+        if (editor) {
+          undoCommand(editor);
+          editor.focus();
+        }
       },
     }),
     [],

--- a/features/transcript-editor/transcript-history-dialog.tsx
+++ b/features/transcript-editor/transcript-history-dialog.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useState } from "react";
+import { History, RotateCcw } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import type { TranscriptRevision } from "@/lib/transcript-draft-store";
+
+type TranscriptHistoryDialogProps = {
+  disabled: boolean;
+  onRestore: (revision: TranscriptRevision) => void;
+  revisions: TranscriptRevision[];
+};
+
+function formatRevisionDate(savedAt: string) {
+  return new Date(savedAt).toLocaleString(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+}
+
+export function TranscriptHistoryDialog({
+  disabled,
+  onRestore,
+  revisions,
+}: TranscriptHistoryDialogProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger
+        render={<Button variant="ghost" size="icon-sm" disabled={disabled} aria-label="Saved history" title="Saved history" />}
+      >
+        <History />
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Saved history</DialogTitle>
+          <DialogDescription>The previous 20 locally saved versions are kept here.</DialogDescription>
+        </DialogHeader>
+
+        {revisions.length ? (
+          <div className="grid max-h-[min(26rem,65vh)] gap-1.5 overflow-y-auto pr-1">
+            {revisions.map((revision) => (
+              <div
+                key={revision.id}
+                className="flex items-center justify-between gap-3 rounded-lg border px-3 py-2.5"
+              >
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-medium" title={revision.fileName}>
+                    {revision.fileName}
+                  </p>
+                  <time
+                    dateTime={revision.savedAt}
+                    suppressHydrationWarning
+                    className="mt-0.5 block font-mono text-[0.68rem] text-muted-foreground"
+                  >
+                    {formatRevisionDate(revision.savedAt)}
+                  </time>
+                </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    onRestore(revision);
+                    setOpen(false);
+                  }}
+                >
+                  <RotateCcw data-icon="inline-start" />
+                  Restore
+                </Button>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="grid min-h-28 place-items-center rounded-lg border border-dashed px-6 text-center text-xs text-muted-foreground">
+            Older versions appear after the transcript is changed and saved again.
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/features/workspace/transcript-workspace.tsx
+++ b/features/workspace/transcript-workspace.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useHotkeys } from "@tanstack/react-hotkeys";
 import {
@@ -8,9 +8,12 @@ import {
   FilePlus2,
   FileText,
   FolderOpen,
+  Redo2,
   RotateCcw,
   Save,
+  Search,
   Timer,
+  Undo2,
   X,
 } from "lucide-react";
 import { toast } from "sonner";
@@ -28,6 +31,7 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Separator } from "@/components/ui/separator";
 import {
   Tooltip,
   TooltipContent,
@@ -39,17 +43,28 @@ import {
 } from "@/features/audio-player/audio-player";
 import {
   TranscriptEditor,
+  type EditorHistoryState,
   type TranscriptEditorHandle,
 } from "@/features/transcript-editor/transcript-editor";
+import { TranscriptHistoryDialog } from "@/features/transcript-editor/transcript-history-dialog";
+import { SpeakerMenu } from "@/features/speakers/speaker-menu";
+import {
+  loadSpeakerSettings,
+  saveSpeakerSettings,
+  type SpeakerDefinition,
+} from "@/features/speakers/speaker-settings-store";
 import {
   downloadTextFile,
   isTextFile,
   normalizeTextFileName,
 } from "@/lib/file-utils";
 import { formatTimestamp } from "@/lib/time-utils";
+import { useModifierKeyLabel } from "@/lib/platform";
 import {
   getTranscriptDraft,
+  getTranscriptHistory,
   saveTranscriptDraft,
+  type TranscriptRevision,
 } from "@/lib/transcript-draft-store";
 
 const INITIAL_FILE_NAME = "untitled.txt";
@@ -60,26 +75,35 @@ type PendingAction =
   | { type: "open"; file: File };
 
 export function TranscriptWorkspace() {
+  const modifierKey = useModifierKeyLabel();
   const router = useRouter();
   const audioPlayerRef = useRef<AudioPlayerHandle>(null);
   const editorRef = useRef<TranscriptEditorHandle>(null);
   const transcriptFileInputRef = useRef<HTMLInputElement>(null);
   const [content, setContent] = useState("");
   const [draftAvailable, setDraftAvailable] = useState(false);
+  const [editorHistoryState, setEditorHistoryState] = useState<EditorHistoryState>({
+    canRedo: false,
+    canUndo: false,
+  });
+  const [editorSessionId, setEditorSessionId] = useState(0);
   const [fileName, setFileName] = useState<string | null>(null);
   const [pendingAction, setPendingAction] = useState<PendingAction | null>(null);
+  const [revisions, setRevisions] = useState<TranscriptRevision[]>([]);
   const [savedContent, setSavedContent] = useState("");
   const [savedFileName, setSavedFileName] = useState<string | null>(null);
+  const [speakers, setSpeakers] = useState<SpeakerDefinition[]>([]);
   const hasTranscript = fileName !== null;
   const isDirty = hasTranscript && (content !== savedContent || fileName !== savedFileName);
 
   useEffect(() => {
     let cancelled = false;
 
-    void getTranscriptDraft()
-      .then((draft) => {
+    void Promise.all([getTranscriptDraft(), getTranscriptHistory()])
+      .then(([draft, storedRevisions]) => {
         if (!cancelled) {
           setDraftAvailable(Boolean(draft));
+          setRevisions(storedRevisions);
         }
       })
       .catch(() => {
@@ -91,6 +115,11 @@ export function TranscriptWorkspace() {
     };
   }, []);
 
+  useEffect(() => {
+    const frame = requestAnimationFrame(() => setSpeakers(loadSpeakerSettings()));
+    return () => cancelAnimationFrame(frame);
+  }, []);
+
   const focusEditor = () => requestAnimationFrame(() => editorRef.current?.focus());
   const openTranscriptPicker = () => transcriptFileInputRef.current?.click();
 
@@ -99,6 +128,8 @@ export function TranscriptWorkspace() {
     setSavedContent("");
     setFileName(INITIAL_FILE_NAME);
     setSavedFileName(INITIAL_FILE_NAME);
+    setEditorHistoryState({ canRedo: false, canUndo: false });
+    setEditorSessionId((current) => current + 1);
     focusEditor();
   };
 
@@ -107,6 +138,7 @@ export function TranscriptWorkspace() {
     setSavedContent("");
     setFileName(null);
     setSavedFileName(null);
+    setEditorHistoryState({ canRedo: false, canUndo: false });
   };
 
   const exportTranscript = () => {
@@ -129,7 +161,7 @@ export function TranscriptWorkspace() {
     const normalizedName = normalizeTextFileName(fileName);
 
     try {
-      await saveTranscriptDraft({
+      const nextRevisions = await saveTranscriptDraft({
         content,
         fileName: normalizedName,
         savedAt: new Date().toISOString(),
@@ -138,6 +170,7 @@ export function TranscriptWorkspace() {
       setSavedFileName(normalizedName);
       setSavedContent(content);
       setDraftAvailable(true);
+      setRevisions(nextRevisions);
     } catch {
       toast.error("The transcript could not be saved in this browser.");
     }
@@ -157,6 +190,8 @@ export function TranscriptWorkspace() {
       setSavedContent(draft.content);
       setFileName(draft.fileName);
       setSavedFileName(draft.fileName);
+      setEditorHistoryState({ canRedo: false, canUndo: false });
+      setEditorSessionId((current) => current + 1);
       focusEditor();
     } catch {
       toast.error("The saved transcript could not be opened.");
@@ -171,6 +206,29 @@ export function TranscriptWorkspace() {
 
     const timestamp = formatTimestamp(audioPlayerRef.current?.getCurrentTime() ?? 0);
     editorRef.current?.insertText(`[${timestamp}] `);
+  };
+
+  const jumpToTimestamp = useCallback((seconds: number) => {
+    audioPlayerRef.current?.seekTo(seconds);
+  }, []);
+
+  const insertSpeaker = useCallback((speaker: SpeakerDefinition) => {
+    editorRef.current?.insertSpeaker(speaker.name);
+  }, []);
+
+  const updateSpeakers = useCallback((nextSpeakers: SpeakerDefinition[]) => {
+    try {
+      saveSpeakerSettings(nextSpeakers);
+      setSpeakers(nextSpeakers);
+    } catch {
+      toast.error("Speaker settings could not be saved in this browser.");
+    }
+  }, []);
+
+  const restoreRevision = (revision: TranscriptRevision) => {
+    setContent(revision.content);
+    setFileName(revision.fileName);
+    focusEditor();
   };
 
   const requestNewTranscript = () => {
@@ -198,6 +256,8 @@ export function TranscriptWorkspace() {
       setSavedContent(nextContent);
       setFileName(file.name);
       setSavedFileName(file.name);
+      setEditorHistoryState({ canRedo: false, canUndo: false });
+      setEditorSessionId((current) => current + 1);
       toast.success(`Opened ${file.name}.`);
       focusEditor();
     } catch {
@@ -259,6 +319,11 @@ export function TranscriptWorkspace() {
         callback: () => audioPlayerRef.current?.seekBy(5),
       },
       { hotkey: "Mod+/", callback: () => router.push("/docs") },
+      ...speakers.flatMap((speaker) =>
+        speaker.shortcut
+          ? [{ hotkey: speaker.shortcut, callback: () => insertSpeaker(speaker) }]
+          : [],
+      ),
     ],
     {
       ignoreInputs: false,
@@ -328,6 +393,66 @@ export function TranscriptWorkspace() {
                 </TooltipTrigger>
                 <TooltipContent>Open transcript</TooltipContent>
               </Tooltip>
+              <Separator orientation="vertical" className="mx-0.5 h-5 self-center" />
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      disabled={!hasTranscript}
+                      onClick={() => editorRef.current?.openSearch()}
+                    />
+                  }
+                >
+                  <Search />
+                  <span className="sr-only">Find and replace</span>
+                </TooltipTrigger>
+                <TooltipContent>Find and replace ({modifierKey} F)</TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      disabled={!hasTranscript || !editorHistoryState.canUndo}
+                      onClick={() => editorRef.current?.undo()}
+                    />
+                  }
+                >
+                  <Undo2 />
+                  <span className="sr-only">Undo edit</span>
+                </TooltipTrigger>
+                <TooltipContent>Undo edit ({modifierKey} Z)</TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      disabled={!hasTranscript || !editorHistoryState.canRedo}
+                      onClick={() => editorRef.current?.redo()}
+                    />
+                  }
+                >
+                  <Redo2 />
+                  <span className="sr-only">Redo edit</span>
+                </TooltipTrigger>
+                <TooltipContent>Redo edit ({modifierKey === "⌘" ? `${modifierKey} Shift Z` : `${modifierKey} Y`})</TooltipContent>
+              </Tooltip>
+              <TranscriptHistoryDialog
+                disabled={!hasTranscript}
+                revisions={revisions}
+                onRestore={restoreRevision}
+              />
+              <SpeakerMenu
+                disabled={!hasTranscript}
+                speakers={speakers}
+                onChange={updateSpeakers}
+                onInsert={insertSpeaker}
+              />
               <Tooltip>
                 <TooltipTrigger
                   render={
@@ -383,7 +508,14 @@ export function TranscriptWorkspace() {
           {hasTranscript ? (
             <>
               <div className="min-h-0 flex-1 overflow-hidden">
-                <TranscriptEditor ref={editorRef} value={content} onChange={setContent} />
+                <TranscriptEditor
+                  key={editorSessionId}
+                  ref={editorRef}
+                  value={content}
+                  onChange={setContent}
+                  onHistoryStateChange={setEditorHistoryState}
+                  onJumpToTime={jumpToTimestamp}
+                />
               </div>
               <footer className="flex h-7 shrink-0 items-center justify-between border-t bg-[var(--workspace-panel)] px-3 font-mono text-[0.65rem] text-muted-foreground">
                 <span>{content.length.toLocaleString()} characters</span>

--- a/lib/platform.ts
+++ b/lib/platform.ts
@@ -1,0 +1,28 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+export type ModifierKeyLabel = "⌘" | "Ctrl";
+
+function subscribe() {
+  return () => {};
+}
+
+export function getModifierKeyLabel(): ModifierKeyLabel {
+  if (typeof navigator === "undefined") {
+    return "Ctrl";
+  }
+
+  const navigatorWithUserAgentData = navigator as Navigator & {
+    userAgentData?: { platform?: string };
+  };
+  const platform =
+    (navigatorWithUserAgentData.userAgentData?.platform ?? navigator.platform) ||
+    navigator.userAgent;
+
+  return /mac|iphone|ipad|ipod/i.test(platform) ? "⌘" : "Ctrl";
+}
+
+export function useModifierKeyLabel() {
+  return useSyncExternalStore(subscribe, getModifierKeyLabel, () => "Ctrl" as const);
+}

--- a/lib/transcript-draft-store.ts
+++ b/lib/transcript-draft-store.ts
@@ -4,12 +4,18 @@ import "client-only";
 const DATABASE_NAME = "transcript-editor";
 const DATABASE_VERSION = 1;
 const DRAFT_KEY = "current";
+const HISTORY_KEY = "history";
+const HISTORY_LIMIT = 20;
 const STORE_NAME = "drafts";
 
 export type TranscriptDraft = {
   content: string;
   fileName: string;
   savedAt: string;
+};
+
+export type TranscriptRevision = TranscriptDraft & {
+  id: string;
 };
 
 function requestResult<T>(request: IDBRequest<T>) {
@@ -52,13 +58,60 @@ export async function getTranscriptDraft() {
   }
 }
 
+export async function getTranscriptHistory() {
+  const database = await openDraftDatabase();
+
+  try {
+    const transaction = database.transaction(STORE_NAME, "readonly");
+    const history = await requestResult(
+      transaction.objectStore(STORE_NAME).get(HISTORY_KEY) as IDBRequest<
+        TranscriptRevision[] | undefined
+      >,
+    );
+
+    return history ?? [];
+  } finally {
+    database.close();
+  }
+}
+
 export async function saveTranscriptDraft(draft: TranscriptDraft) {
   const database = await openDraftDatabase();
 
   try {
     const transaction = database.transaction(STORE_NAME, "readwrite");
-    transaction.objectStore(STORE_NAME).put(draft, DRAFT_KEY);
+    const store = transaction.objectStore(STORE_NAME);
+    const [currentDraft, storedHistory] = await Promise.all([
+      requestResult(store.get(DRAFT_KEY) as IDBRequest<TranscriptDraft | undefined>),
+      requestResult(store.get(HISTORY_KEY) as IDBRequest<TranscriptRevision[] | undefined>),
+    ]);
+    let history = (storedHistory ?? []).filter(
+      (revision) => revision.content !== draft.content || revision.fileName !== draft.fileName,
+    );
+
+    if (
+      currentDraft &&
+      (currentDraft.content !== draft.content || currentDraft.fileName !== draft.fileName)
+    ) {
+      const revision: TranscriptRevision = {
+        ...currentDraft,
+        id: `${currentDraft.savedAt}-${crypto.randomUUID()}`,
+      };
+      history = [
+        revision,
+        ...history.filter(
+          (storedRevision) =>
+            storedRevision.content !== revision.content ||
+            storedRevision.fileName !== revision.fileName,
+        ),
+      ].slice(0, HISTORY_LIMIT);
+    }
+
+    store.put(draft, DRAFT_KEY);
+    store.put(history, HISTORY_KEY);
     await transactionComplete(transaction);
+
+    return history;
   } finally {
     database.close();
   }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.7.0",
+    "@codemirror/commands": "^6.11.0",
+    "@codemirror/search": "^6.7.1",
+    "@codemirror/state": "^6.7.1",
     "@codemirror/view": "^6.43.9",
     "@tanstack/react-hotkeys": "^0.10.0",
     "class-variance-authority": "^0.7.1",
@@ -22,7 +25,6 @@
     "codemirror": "^6.0.2",
     "lucide-react": "^1.31.0",
     "next": "16.3.1",
-    "next-themes": "^0.4.6",
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "sonner": "^2.0.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,15 @@ importers:
       '@base-ui/react':
         specifier: ^1.7.0
         version: 1.7.0(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@codemirror/commands':
+        specifier: ^6.11.0
+        version: 6.11.0
+      '@codemirror/search':
+        specifier: ^6.7.1
+        version: 6.7.1
+      '@codemirror/state':
+        specifier: ^6.7.1
+        version: 6.7.1
       '@codemirror/view':
         specifier: ^6.43.9
         version: 6.43.9
@@ -32,9 +41,6 @@ importers:
       next:
         specifier: 16.3.1
         version: 16.3.1(@babel/core@7.29.7)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      next-themes:
-        specifier: ^0.4.6
-        version: 0.4.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -2256,12 +2262,6 @@ packages:
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
-
-  next-themes@0.4.6:
-    resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
-    peerDependencies:
-      react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
   next@16.3.1:
     resolution: {integrity: sha512-hsAp0i7Rh+/dhe7DGIeN2YlpLM1DP4MNxti9EtDMtqcO612X81MvvEj388/oTce9U1EcEIOWDlGq0zRwrBKvuA==}
@@ -5309,11 +5309,6 @@ snapshots:
   natural-compare@1.4.0: {}
 
   negotiator@1.0.0: {}
-
-  next-themes@0.4.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
-    dependencies:
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
 
   next@16.3.1(@babel/core@7.29.7)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:


### PR DESCRIPTION
## Summary

- add contextual timestamp-to-audio jumping, a fixed two-second resume rewind, and separate 1/5-second seek controls
- add CodeMirror undo/redo controls, a custom native-backed find/replace panel, and current transcript plus 20 saved revisions
- add configurable speaker text with platform-aware shortcuts and browser-specific shortcut hints
- replace next-themes with a hydration-safe local theme store and pre-hydration initializer
- update Docs, About, and README for the new workflow

## Validation

- pnpm lint
- pnpm typecheck
- pnpm build

UI verification is intentionally left to the repository owner.