### PR TITLE
Centralize keyboard shortcut metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Geist is loaded through `next/font/google`. Next.js downloads it during the buil
 
 1. Open an audio recording in the left panel.
 2. Create an empty transcript, restore a browser-local draft, or open an existing `.txt` file on the right.
-3. Use `Ctrl/⌘+S` to save the current transcript locally in the browser.
-4. Use `Ctrl/⌘+Shift+S` or the Export button to download a text file.
+3. Save the current transcript locally using the toolbar or the platform-specific shortcut listed in Docs.
+4. Use the Export button to download a text file.
 
 The Docs page lists every keyboard shortcut, and the About page explains the academic work that motivated the project.
 

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
   },
 };
 
-const DOCUMENTED_SHORTCUTS = Object.values(SHORTCUTS).filter((shortcut) => shortcut.group !== null);
+const DOCUMENTED_SHORTCUTS = Object.entries(SHORTCUTS).filter(([, shortcut]) => shortcut.group !== null);
 
 export default function DocsPage() {
   return (
@@ -40,8 +40,8 @@ export default function DocsPage() {
               <div key={group.id}>
                 <h3 className="text-sm font-medium">{group.label}</h3>
                 <dl className="mt-3 grid gap-3">
-                  {DOCUMENTED_SHORTCUTS.filter((shortcut) => shortcut.group === group.id).map((shortcut) => (
-                    <div key={shortcut.description} className="grid gap-1.5">
+                  {DOCUMENTED_SHORTCUTS.filter(([, shortcut]) => shortcut.group === group.id).map(([shortcutId, shortcut]) => (
+                    <div key={shortcutId} className="grid gap-1.5">
                       <dt className="text-xs text-muted-foreground">{shortcut.description}</dt>
                       <dd className="flex flex-wrap items-center gap-1">
                         <ShortcutKeys shortcut={shortcut} />

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 
-import { ModifierKey, ShortcutKeys } from "@/components/shortcut-keys";
+import { ShortcutKeys } from "@/components/shortcut-keys";
+import { SHORTCUT_GROUPS, SHORTCUTS } from "@/lib/shortcuts";
 
 export const metadata: Metadata = {
   title: "Docs",
@@ -10,35 +11,7 @@ export const metadata: Metadata = {
   },
 };
 
-const SHORTCUT_GROUPS = [
-  {
-    title: "Files",
-    shortcuts: [
-      ["Open transcript", ["Mod", "O"]],
-      ["Open audio", ["Mod", "Shift", "O"]],
-      ["Save transcript locally", ["Mod", "S"]],
-      ["Export text file", ["Mod", "Shift", "S"]],
-    ],
-  },
-  {
-    title: "Playback",
-    shortcuts: [
-      ["Play or pause", ["Mod", "Enter"]],
-      ["Back five seconds", ["Mod", "Shift", "←"]],
-      ["Forward five seconds", ["Mod", "Shift", "→"]],
-      ["Insert timestamp", ["Mod", "J"]],
-    ],
-  },
-  {
-    title: "Editor",
-    shortcuts: [
-      ["Find and replace", ["Mod", "F"]],
-      ["Undo", ["Mod", "Z"]],
-      ["Redo", ["Mod", "Y"], ["Mod", "Shift", "Z"]],
-      ["Open documentation", ["Mod", "/"]],
-    ],
-  },
-] as const;
+const DOCUMENTED_SHORTCUTS = Object.values(SHORTCUTS).filter((shortcut) => shortcut.group !== null);
 
 export default function DocsPage() {
   return (
@@ -64,14 +37,14 @@ export default function DocsPage() {
           </h2>
           <div className="mt-5 grid gap-8 md:grid-cols-3">
             {SHORTCUT_GROUPS.map((group) => (
-              <div key={group.title}>
-                <h3 className="text-sm font-medium">{group.title}</h3>
+              <div key={group.id}>
+                <h3 className="text-sm font-medium">{group.label}</h3>
                 <dl className="mt-3 grid gap-3">
-                  {group.shortcuts.map(([label, keys, macKeys]) => (
-                    <div key={label} className="grid gap-1.5">
-                      <dt className="text-xs text-muted-foreground">{label}</dt>
+                  {DOCUMENTED_SHORTCUTS.filter((shortcut) => shortcut.group === group.id).map((shortcut) => (
+                    <div key={shortcut.description} className="grid gap-1.5">
+                      <dt className="text-xs text-muted-foreground">{shortcut.description}</dt>
                       <dd className="flex flex-wrap items-center gap-1">
-                        <ShortcutKeys keys={keys} macKeys={macKeys} />
+                        <ShortcutKeys shortcut={shortcut} />
                       </dd>
                     </div>
                   ))}
@@ -86,7 +59,7 @@ export default function DocsPage() {
             Editing workflow
           </h2>
           <ul className="mt-4 grid list-disc gap-2 pl-5 text-sm leading-6 text-muted-foreground">
-            <li>Hover a timestamp or place the cursor inside it to reveal a jump action. <ModifierKey />-clicking the timestamp jumps immediately.</li>
+            <li>Hover a timestamp or place the cursor inside it to reveal a jump action. <ShortcutKeys shortcut={SHORTCUTS.jumpToTimestamp} /> jumps immediately.</li>
             <li>Find and replace opens from the transcript toolbar or its keyboard shortcut. Undo and redo work on individual editor changes.</li>
             <li>Saving keeps the previous 20 local versions under Saved history.</li>
             <li>Speaker text is inserted exactly as configured, with an optional shortcut set from the Speakers control in the transcript toolbar.</li>

--- a/components/shortcut-keys.tsx
+++ b/components/shortcut-keys.tsx
@@ -2,14 +2,18 @@
 
 import { Kbd } from "@/components/ui/kbd";
 import { useModifierKeyLabel } from "@/lib/platform";
+import { cn } from "@/lib/utils";
+import { getPlatformShortcutKeys, type ShortcutDisplay } from "@/lib/shortcuts";
 
-export function ModifierKey() {
-  return useModifierKeyLabel();
-}
-
-export function ShortcutKeys({ keys, macKeys }: { keys: readonly string[]; macKeys?: readonly string[] }) {
+export function ShortcutKeys({ className, shortcut }: { className?: string; shortcut: ShortcutDisplay }) {
   const modifierKey = useModifierKeyLabel();
-  const visibleKeys = modifierKey === "⌘" && macKeys ? macKeys : keys;
+  const visibleKeys = getPlatformShortcutKeys(shortcut, modifierKey);
 
-  return visibleKeys.map((key) => <Kbd key={key}>{key === "Mod" ? modifierKey : key}</Kbd>);
+  return (
+    <span className={cn("inline-flex items-center gap-1", className)}>
+      {visibleKeys.map((key) => (
+        <Kbd key={key}>{key}</Kbd>
+      ))}
+    </span>
+  );
 }

--- a/components/shortcut-tooltip-content.tsx
+++ b/components/shortcut-tooltip-content.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { ShortcutKeys } from "@/components/shortcut-keys";
+import { TooltipContent } from "@/components/ui/tooltip";
+import type { ShortcutDefinition } from "@/lib/shortcuts";
+
+export function ShortcutTooltipContent({ shortcut }: { shortcut: ShortcutDefinition }) {
+  return (
+    <TooltipContent>
+      <span>{shortcut.description}</span>
+      <ShortcutKeys shortcut={shortcut} />
+    </TooltipContent>
+  );
+}

--- a/features/audio-player/audio-player.tsx
+++ b/features/audio-player/audio-player.tsx
@@ -17,6 +17,7 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { ShortcutTooltipContent } from "@/components/shortcut-tooltip-content";
 import {
   Select,
   SelectContent,
@@ -32,6 +33,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { formatTimestamp } from "@/lib/time-utils";
+import { SHORTCUTS, type ShortcutDefinition } from "@/lib/shortcuts";
 import { useAudioPlayer } from "./use-audio-player";
 
 const PLAYBACK_RATES = [0.5, 0.75, 1, 1.25, 1.5, 2];
@@ -52,7 +54,7 @@ function formatFileSize(bytes: number) {
   return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
 }
 
-function SeekButton({ seconds, onSeek }: { seconds: -5 | -1 | 1 | 5; onSeek: () => void }) {
+function SeekButton({ seconds, onSeek, shortcut }: { seconds: -5 | -1 | 1 | 5; onSeek: () => void; shortcut?: ShortcutDefinition }) {
   const direction = seconds < 0 ? "Back" : "Forward";
   const amount = Math.abs(seconds);
   const label = `${direction} ${amount} ${amount === 1 ? "second" : "seconds"}`;
@@ -72,7 +74,7 @@ function SeekButton({ seconds, onSeek }: { seconds: -5 | -1 | 1 | 5; onSeek: () 
         {seconds > 0 ? `+${seconds}` : `−${amount}`}
         <span className="sr-only">{label}</span>
       </TooltipTrigger>
-      <TooltipContent>{label}</TooltipContent>
+      {shortcut ? <ShortcutTooltipContent shortcut={shortcut} /> : <TooltipContent>{label}</TooltipContent>}
     </Tooltip>
   );
 }
@@ -139,10 +141,15 @@ export const AudioPlayer = forwardRef<AudioPlayerHandle>(
               Local
             </Badge>
           </div>
-          <Button variant="outline" size="sm" onClick={() => fileInputRef.current?.click()}>
-            <Upload data-icon="inline-start" />
-            Open
-          </Button>
+          <Tooltip>
+            <TooltipTrigger
+              render={<Button variant="outline" size="sm" onClick={() => fileInputRef.current?.click()} />}
+            >
+              <Upload data-icon="inline-start" />
+              Open
+            </TooltipTrigger>
+            <ShortcutTooltipContent shortcut={SHORTCUTS.openAudio} />
+          </Tooltip>
         </div>
 
         {!file ? (
@@ -221,24 +228,31 @@ export const AudioPlayer = forwardRef<AudioPlayerHandle>(
             </div>
 
             <div className="flex items-center justify-center gap-1.5 px-3 pb-4">
-              <SeekButton seconds={-5} onSeek={() => seekBy(-5)} />
+              <SeekButton seconds={-5} onSeek={() => seekBy(-5)} shortcut={SHORTCUTS.seekBackFive} />
               <SeekButton seconds={-1} onSeek={() => seekBy(-1)} />
-              <Button
-                size="icon-lg"
-                className="mx-0.5 size-11 rounded-full shadow-sm"
-                onClick={togglePlayback}
-                aria-label={isPlaying ? "Pause audio" : "Play audio"}
-              >
-                {isLoading ? (
-                  <LoaderCircle className="animate-spin" />
-                ) : isPlaying ? (
-                  <Pause className="fill-current" />
-                ) : (
-                  <Play className="ml-0.5 fill-current" />
-                )}
-              </Button>
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <Button
+                      size="icon-lg"
+                      className="mx-0.5 size-11 rounded-full shadow-sm"
+                      onClick={togglePlayback}
+                      aria-label={isPlaying ? "Pause audio" : "Play audio"}
+                    />
+                  }
+                >
+                  {isLoading ? (
+                    <LoaderCircle className="animate-spin" />
+                  ) : isPlaying ? (
+                    <Pause className="fill-current" />
+                  ) : (
+                    <Play className="ml-0.5 fill-current" />
+                  )}
+                </TooltipTrigger>
+                <ShortcutTooltipContent shortcut={SHORTCUTS.togglePlayback} />
+              </Tooltip>
               <SeekButton seconds={1} onSeek={() => seekBy(1)} />
-              <SeekButton seconds={5} onSeek={() => seekBy(5)} />
+              <SeekButton seconds={5} onSeek={() => seekBy(5)} shortcut={SHORTCUTS.seekForwardFive} />
             </div>
 
             <Separator />

--- a/features/speakers/speaker-menu.tsx
+++ b/features/speakers/speaker-menu.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { Settings2, Trash2, UserRoundPlus, UsersRound } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { ShortcutKeys } from "@/components/shortcut-keys";
 import {
   Dialog,
   DialogContent,
@@ -13,7 +14,6 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
-import { Kbd } from "@/components/ui/kbd";
 import {
   Popover,
   PopoverContent,
@@ -29,11 +29,14 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import {
-  getSpeakerShortcutLabel,
-  isSpeakerShortcut,
-  SPEAKER_SHORTCUT_OPTIONS,
   type SpeakerDefinition,
 } from "./speaker-settings-store";
+import {
+  formatShortcutLabel,
+  getSpeakerShortcut,
+  isSpeakerShortcut,
+  SPEAKER_SHORTCUT_OPTIONS,
+} from "@/lib/shortcuts";
 import { useModifierKeyLabel } from "@/lib/platform";
 
 type SpeakerMenuProps = {
@@ -49,7 +52,6 @@ function normalizeSpeakerName(name: string) {
 
 export function SpeakerMenu({ disabled, onChange, onInsert, speakers }: SpeakerMenuProps) {
   const modifierKey = useModifierKeyLabel();
-  const alternateKey = modifierKey === "⌘" ? "Option" : "Alt";
   const [draftSpeakers, setDraftSpeakers] = useState<SpeakerDefinition[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [popoverOpen, setPopoverOpen] = useState(false);
@@ -58,7 +60,7 @@ export function SpeakerMenu({ disabled, onChange, onInsert, speakers }: SpeakerM
   const openSettings = () => {
     const initialSpeakers = speakers.length
       ? speakers.map((speaker) => ({ ...speaker }))
-      : [{ id: crypto.randomUUID(), name: "", shortcut: SPEAKER_SHORTCUT_OPTIONS[0]?.value ?? null }];
+      : [{ id: crypto.randomUUID(), name: "", shortcut: SPEAKER_SHORTCUT_OPTIONS[0]?.hotkey ?? null }];
     setDraftSpeakers(initialSpeakers);
     setError(null);
     setPopoverOpen(false);
@@ -68,7 +70,7 @@ export function SpeakerMenu({ disabled, onChange, onInsert, speakers }: SpeakerM
   const addSpeaker = () => {
     const usedShortcuts = new Set(draftSpeakers.map((speaker) => speaker.shortcut));
     const shortcut =
-      SPEAKER_SHORTCUT_OPTIONS.find((option) => !usedShortcuts.has(option.value))?.value ?? null;
+      SPEAKER_SHORTCUT_OPTIONS.find((option) => !usedShortcuts.has(option.hotkey))?.hotkey ?? null;
     setDraftSpeakers((current) => [
       ...current,
       { id: crypto.randomUUID(), name: "", shortcut },
@@ -135,7 +137,7 @@ export function SpeakerMenu({ disabled, onChange, onInsert, speakers }: SpeakerM
           {speakers.length ? (
             <div className="grid gap-1">
               {speakers.map((speaker) => {
-                const shortcutLabel = getSpeakerShortcutLabel(speaker.shortcut, modifierKey, alternateKey);
+                const shortcut = getSpeakerShortcut(speaker.shortcut);
                 return (
                   <Button
                     key={speaker.id}
@@ -147,7 +149,7 @@ export function SpeakerMenu({ disabled, onChange, onInsert, speakers }: SpeakerM
                     }}
                   >
                     <span className="truncate">{speaker.name}</span>
-                    {shortcutLabel ? <Kbd>{shortcutLabel}</Kbd> : null}
+                    {shortcut ? <ShortcutKeys shortcut={shortcut} /> : null}
                   </Button>
                 );
               })}
@@ -195,11 +197,11 @@ export function SpeakerMenu({ disabled, onChange, onInsert, speakers }: SpeakerM
                     {SPEAKER_SHORTCUT_OPTIONS.map((option) => {
                       const assignedElsewhere = draftSpeakers.some(
                         (candidate) =>
-                          candidate.id !== speaker.id && candidate.shortcut === option.value,
+                          candidate.id !== speaker.id && candidate.shortcut === option.hotkey,
                       );
                       return (
-                        <SelectItem key={option.value} value={option.value} disabled={assignedElsewhere}>
-                          {modifierKey} {alternateKey} {option.number}
+                        <SelectItem key={option.hotkey} value={option.hotkey} disabled={assignedElsewhere}>
+                          {formatShortcutLabel(option, modifierKey)}
                         </SelectItem>
                       );
                     })}

--- a/features/speakers/speaker-settings-store.ts
+++ b/features/speakers/speaker-settings-store.ts
@@ -1,26 +1,18 @@
 import "client-only";
 
+import {
+  isSpeakerShortcut,
+  SPEAKER_SHORTCUT_OPTIONS,
+  type SpeakerShortcut,
+} from "@/lib/shortcuts";
+
 const STORAGE_KEY = "transcript-desk:speakers:v1";
-
-export type SpeakerShortcut = `Mod+Alt+${1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9}`;
-
-export const SPEAKER_SHORTCUT_OPTIONS = Array.from({ length: 9 }, (_, index) => {
-  const number = index + 1;
-  return {
-    number,
-    value: `Mod+Alt+${number}` as SpeakerShortcut,
-  };
-});
 
 export type SpeakerDefinition = {
   id: string;
   name: string;
   shortcut: SpeakerShortcut | null;
 };
-
-export function isSpeakerShortcut(value: unknown): value is SpeakerShortcut {
-  return SPEAKER_SHORTCUT_OPTIONS.some((option) => option.value === value);
-}
 
 function isSpeakerDefinition(value: unknown): value is SpeakerDefinition {
   if (!value || typeof value !== "object") {
@@ -33,11 +25,6 @@ function isSpeakerDefinition(value: unknown): value is SpeakerDefinition {
     typeof speaker.name === "string" &&
     (speaker.shortcut === null || isSpeakerShortcut(speaker.shortcut))
   );
-}
-
-export function getSpeakerShortcutLabel(shortcut: string | null, modifierKey: string, alternateKey: string) {
-  const option = SPEAKER_SHORTCUT_OPTIONS.find((candidate) => candidate.value === shortcut);
-  return option ? `${modifierKey} ${alternateKey} ${option.number}` : null;
 }
 
 export function loadSpeakerSettings() {

--- a/features/transcript-editor/timestamp-jump-extension.ts
+++ b/features/transcript-editor/timestamp-jump-extension.ts
@@ -8,6 +8,7 @@ import {
 
 import { parseTimestamp } from "@/lib/time-utils";
 import { getModifierKeyLabel } from "@/lib/platform";
+import { formatShortcutLabel, SHORTCUTS } from "@/lib/shortcuts";
 
 const TIMESTAMP_PATTERN = /\[(\d{1,2}:[0-5]\d:[0-5]\d)\]/g;
 
@@ -69,7 +70,10 @@ function createJumpTooltip(
       button.textContent = `Jump to ${match.label}`;
       button.setAttribute("aria-label", `Jump audio to ${match.label}`);
       shortcut.className = "cm-timestamp-jump-shortcut";
-      shortcut.textContent = `${getModifierKeyLabel()} click`;
+      shortcut.textContent = formatShortcutLabel(
+        SHORTCUTS.jumpToTimestamp,
+        getModifierKeyLabel(),
+      );
       button.append(shortcut);
       button.addEventListener("mousedown", (event) => event.preventDefault());
       button.addEventListener("click", () => onJumpToTime(match.seconds));

--- a/features/workspace/transcript-workspace.tsx
+++ b/features/workspace/transcript-workspace.tsx
@@ -31,6 +31,7 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { ShortcutTooltipContent } from "@/components/shortcut-tooltip-content";
 import { Separator } from "@/components/ui/separator";
 import {
   Tooltip,
@@ -59,7 +60,7 @@ import {
   normalizeTextFileName,
 } from "@/lib/file-utils";
 import { formatTimestamp } from "@/lib/time-utils";
-import { useModifierKeyLabel } from "@/lib/platform";
+import { SHORTCUTS } from "@/lib/shortcuts";
 import {
   getTranscriptDraft,
   getTranscriptHistory,
@@ -75,7 +76,6 @@ type PendingAction =
   | { type: "open"; file: File };
 
 export function TranscriptWorkspace() {
-  const modifierKey = useModifierKeyLabel();
   const router = useRouter();
   const audioPlayerRef = useRef<AudioPlayerHandle>(null);
   const editorRef = useRef<TranscriptEditorHandle>(null);
@@ -298,27 +298,27 @@ export function TranscriptWorkspace() {
 
   useHotkeys(
     [
-      { hotkey: "Mod+S", callback: () => void saveTranscript() },
-      { hotkey: "Mod+Shift+S", callback: exportTranscript },
-      { hotkey: "Mod+O", callback: openTranscriptPicker },
+      { hotkey: SHORTCUTS.saveTranscript.hotkey, callback: () => void saveTranscript() },
+      { hotkey: SHORTCUTS.exportTranscript.hotkey, callback: exportTranscript },
+      { hotkey: SHORTCUTS.openTranscript.hotkey, callback: openTranscriptPicker },
       {
-        hotkey: "Mod+Shift+O",
+        hotkey: SHORTCUTS.openAudio.hotkey,
         callback: () => audioPlayerRef.current?.openFilePicker(),
       },
       {
-        hotkey: "Mod+Enter",
+        hotkey: SHORTCUTS.togglePlayback.hotkey,
         callback: () => audioPlayerRef.current?.togglePlayback(),
       },
-      { hotkey: "Mod+J", callback: insertTimestamp },
+      { hotkey: SHORTCUTS.insertTimestamp.hotkey, callback: insertTimestamp },
       {
-        hotkey: "Mod+Shift+ArrowLeft",
+        hotkey: SHORTCUTS.seekBackFive.hotkey,
         callback: () => audioPlayerRef.current?.seekBy(-5),
       },
       {
-        hotkey: "Mod+Shift+ArrowRight",
+        hotkey: SHORTCUTS.seekForwardFive.hotkey,
         callback: () => audioPlayerRef.current?.seekBy(5),
       },
-      { hotkey: "Mod+/", callback: () => router.push("/docs") },
+      { hotkey: SHORTCUTS.openDocumentation.hotkey, callback: () => router.push("/docs") },
       ...speakers.flatMap((speaker) =>
         speaker.shortcut
           ? [{ hotkey: speaker.shortcut, callback: () => insertSpeaker(speaker) }]
@@ -389,9 +389,9 @@ export function TranscriptWorkspace() {
                   render={<Button variant="ghost" size="icon-sm" onClick={openTranscriptPicker} />}
                 >
                   <FolderOpen />
-                  <span className="sr-only">Open transcript</span>
+                  <span className="sr-only">{SHORTCUTS.openTranscript.description}</span>
                 </TooltipTrigger>
-                <TooltipContent>Open transcript</TooltipContent>
+                <ShortcutTooltipContent shortcut={SHORTCUTS.openTranscript} />
               </Tooltip>
               <Separator orientation="vertical" className="mx-0.5 h-5 self-center" />
               <Tooltip>
@@ -406,9 +406,9 @@ export function TranscriptWorkspace() {
                   }
                 >
                   <Search />
-                  <span className="sr-only">Find and replace</span>
+                  <span className="sr-only">{SHORTCUTS.findAndReplace.description}</span>
                 </TooltipTrigger>
-                <TooltipContent>Find and replace ({modifierKey} F)</TooltipContent>
+                <ShortcutTooltipContent shortcut={SHORTCUTS.findAndReplace} />
               </Tooltip>
               <Tooltip>
                 <TooltipTrigger
@@ -422,9 +422,9 @@ export function TranscriptWorkspace() {
                   }
                 >
                   <Undo2 />
-                  <span className="sr-only">Undo edit</span>
+                  <span className="sr-only">{SHORTCUTS.undoEdit.description}</span>
                 </TooltipTrigger>
-                <TooltipContent>Undo edit ({modifierKey} Z)</TooltipContent>
+                <ShortcutTooltipContent shortcut={SHORTCUTS.undoEdit} />
               </Tooltip>
               <Tooltip>
                 <TooltipTrigger
@@ -438,9 +438,9 @@ export function TranscriptWorkspace() {
                   }
                 >
                   <Redo2 />
-                  <span className="sr-only">Redo edit</span>
+                  <span className="sr-only">{SHORTCUTS.redoEdit.description}</span>
                 </TooltipTrigger>
-                <TooltipContent>Redo edit ({modifierKey === "⌘" ? `${modifierKey} Shift Z` : `${modifierKey} Y`})</TooltipContent>
+                <ShortcutTooltipContent shortcut={SHORTCUTS.redoEdit} />
               </Tooltip>
               <TranscriptHistoryDialog
                 disabled={!hasTranscript}
@@ -465,9 +465,9 @@ export function TranscriptWorkspace() {
                   }
                 >
                   <Timer />
-                  <span className="sr-only">Insert timestamp</span>
+                  <span className="sr-only">{SHORTCUTS.insertTimestamp.description}</span>
                 </TooltipTrigger>
-                <TooltipContent>Insert current timestamp</TooltipContent>
+                <ShortcutTooltipContent shortcut={SHORTCUTS.insertTimestamp} />
               </Tooltip>
               {hasTranscript ? (
                 <Tooltip>
@@ -494,14 +494,19 @@ export function TranscriptWorkspace() {
                   }
                 >
                   <Save />
-                  <span className="sr-only">Save transcript locally</span>
+                  <span className="sr-only">{SHORTCUTS.saveTranscript.description}</span>
                 </TooltipTrigger>
-                <TooltipContent>Save locally</TooltipContent>
+                <ShortcutTooltipContent shortcut={SHORTCUTS.saveTranscript} />
               </Tooltip>
-              <Button size="sm" disabled={!hasTranscript} onClick={exportTranscript}>
-                <Download data-icon="inline-start" />
-                <span className="hidden sm:inline">Export</span>
-              </Button>
+              <Tooltip>
+                <TooltipTrigger
+                  render={<Button size="sm" disabled={!hasTranscript} aria-label={SHORTCUTS.exportTranscript.description} onClick={exportTranscript} />}
+                >
+                  <Download data-icon="inline-start" />
+                  <span className="hidden sm:inline">Export</span>
+                </TooltipTrigger>
+                <ShortcutTooltipContent shortcut={SHORTCUTS.exportTranscript} />
+              </Tooltip>
             </div>
           </div>
 

--- a/lib/shortcuts.ts
+++ b/lib/shortcuts.ts
@@ -1,0 +1,141 @@
+import type { ModifierKeyLabel } from "@/lib/platform";
+
+export const SHORTCUT_GROUPS = [
+  { id: "files", label: "Files" },
+  { id: "playback", label: "Playback" },
+  { id: "editor", label: "Editor" },
+] as const;
+
+export type ShortcutGroupId = (typeof SHORTCUT_GROUPS)[number]["id"];
+
+export type ShortcutDisplay =
+  | {
+      hotkey: string;
+      macHotkey?: string;
+    }
+  | {
+      hotkey: null;
+      keys: readonly string[];
+    };
+
+export type ShortcutDefinition = ShortcutDisplay & {
+  description: string;
+  group: ShortcutGroupId | null;
+};
+
+export const SHORTCUTS = {
+  openTranscript: {
+    description: "Open transcript",
+    group: "files",
+    hotkey: "Mod+O",
+  },
+  openAudio: {
+    description: "Open audio",
+    group: "files",
+    hotkey: "Mod+Shift+O",
+  },
+  saveTranscript: {
+    description: "Save transcript locally",
+    group: "files",
+    hotkey: "Mod+S",
+  },
+  exportTranscript: {
+    description: "Export text file",
+    group: "files",
+    hotkey: "Mod+Shift+S",
+  },
+  togglePlayback: {
+    description: "Play or pause",
+    group: "playback",
+    hotkey: "Mod+Enter",
+  },
+  seekBackFive: {
+    description: "Back five seconds",
+    group: "playback",
+    hotkey: "Mod+Shift+ArrowLeft",
+  },
+  seekForwardFive: {
+    description: "Forward five seconds",
+    group: "playback",
+    hotkey: "Mod+Shift+ArrowRight",
+  },
+  insertTimestamp: {
+    description: "Insert current timestamp",
+    group: "playback",
+    hotkey: "Mod+J",
+  },
+  findAndReplace: {
+    description: "Find and replace",
+    group: "editor",
+    hotkey: "Mod+F",
+  },
+  undoEdit: {
+    description: "Undo edit",
+    group: "editor",
+    hotkey: "Mod+Z",
+  },
+  redoEdit: {
+    description: "Redo edit",
+    group: "editor",
+    hotkey: "Mod+Y",
+    macHotkey: "Mod+Shift+Z",
+  },
+  openDocumentation: {
+    description: "Open documentation",
+    group: "editor",
+    hotkey: "Mod+/",
+  },
+  jumpToTimestamp: {
+    description: "Jump audio to timestamp",
+    group: null,
+    hotkey: null,
+    keys: ["Mod", "Click"],
+  },
+} as const satisfies Record<string, ShortcutDefinition>;
+
+export type ShortcutId = keyof typeof SHORTCUTS;
+
+export type SpeakerShortcut = `Mod+Alt+${1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9}`;
+
+export const SPEAKER_SHORTCUT_OPTIONS = Array.from({ length: 9 }, (_, index) => {
+  const number = index + 1;
+  return {
+    hotkey: `Mod+Alt+${number}` as SpeakerShortcut,
+    number,
+  } satisfies ShortcutDisplay & { hotkey: SpeakerShortcut; number: number };
+});
+
+export function isSpeakerShortcut(value: unknown): value is SpeakerShortcut {
+  return SPEAKER_SHORTCUT_OPTIONS.some((option) => option.hotkey === value);
+}
+
+export function getSpeakerShortcut(shortcut: SpeakerShortcut | null) {
+  return SPEAKER_SHORTCUT_OPTIONS.find((option) => option.hotkey === shortcut) ?? null;
+}
+
+export function getPlatformShortcutKeys(shortcut: ShortcutDisplay, modifierKey: ModifierKeyLabel) {
+  const isApplePlatform = modifierKey === "⌘";
+  const keys = shortcut.hotkey === null
+    ? shortcut.keys
+    : (isApplePlatform && shortcut.macHotkey ? shortcut.macHotkey : shortcut.hotkey).split("+");
+
+  return keys.map((key) => {
+    if (key === "Mod") {
+      return modifierKey;
+    }
+    if (key === "Alt" && isApplePlatform) {
+      return "Option";
+    }
+    if (key === "ArrowLeft") {
+      return "←";
+    }
+    if (key === "ArrowRight") {
+      return "→";
+    }
+    return key;
+  });
+}
+
+export function formatShortcutLabel(shortcut: ShortcutDisplay, modifierKey: ModifierKeyLabel) {
+  return getPlatformShortcutKeys(shortcut, modifierKey).join(" + ");
+}


### PR DESCRIPTION
## Summary

- centralize app and configurable speaker shortcut metadata, descriptions, and OS-aware labels
- render the Docs shortcut groups and shared tooltip content from the same registry
- show shortcut hints on timestamp, file, editor, playback, and five-second seek controls
- derive displayed keys from the runtime hotkey strings to prevent drift
- keep Create empty transcript description-only because Ctrl+N is browser-reserved

## Validation

- pnpm lint
- pnpm typecheck
- pnpm build

UI verification is intentionally left to the repository owner.