### PR TITLE
Fix cross-platform speaker shortcuts

### DIFF
--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -62,7 +62,7 @@ export default function DocsPage() {
             <li>Hover a timestamp or place the cursor inside it to reveal a jump action. <ShortcutKeys shortcut={SHORTCUTS.jumpToTimestamp} /> jumps immediately.</li>
             <li>Find and replace opens from the transcript toolbar or its keyboard shortcut. Undo and redo work on individual editor changes.</li>
             <li>Saving keeps the previous 20 local versions under Saved history.</li>
-            <li>Speaker text is inserted exactly as configured, with an optional shortcut set from the Speakers control in the transcript toolbar.</li>
+            <li>Speaker text is inserted exactly as configured. Open the speaker picker with <ShortcutKeys shortcut={SHORTCUTS.chooseSpeaker} />, then press the configured number.</li>
             <li>Playback resumes two seconds before the paused position. The transport controls provide separate 1- and 5-second jumps in both directions.</li>
           </ul>
         </section>

--- a/features/speakers/speaker-menu.tsx
+++ b/features/speakers/speaker-menu.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useHotkeys } from "@tanstack/react-hotkeys";
 import { Settings2, Trash2, UserRoundPlus, UsersRound } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -35,14 +36,17 @@ import {
   formatShortcutLabel,
   getSpeakerShortcut,
   isSpeakerShortcut,
+  SHORTCUTS,
   SPEAKER_SHORTCUT_OPTIONS,
 } from "@/lib/shortcuts";
 import { useModifierKeyLabel } from "@/lib/platform";
 
 type SpeakerMenuProps = {
   disabled: boolean;
+  open: boolean;
   onChange: (speakers: SpeakerDefinition[]) => void;
   onInsert: (speaker: SpeakerDefinition) => void;
+  onOpenChange: (open: boolean) => void;
   speakers: SpeakerDefinition[];
 };
 
@@ -50,12 +54,31 @@ function normalizeSpeakerName(name: string) {
   return name.trim();
 }
 
-export function SpeakerMenu({ disabled, onChange, onInsert, speakers }: SpeakerMenuProps) {
+export function SpeakerMenu({ disabled, open, onChange, onInsert, onOpenChange, speakers }: SpeakerMenuProps) {
   const modifierKey = useModifierKeyLabel();
   const [draftSpeakers, setDraftSpeakers] = useState<SpeakerDefinition[]>([]);
   const [error, setError] = useState<string | null>(null);
-  const [popoverOpen, setPopoverOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
+
+  const insertAndClose = (speaker: SpeakerDefinition) => {
+    onOpenChange(false);
+    requestAnimationFrame(() => onInsert(speaker));
+  };
+
+  useHotkeys(
+    speakers.flatMap((speaker) =>
+      speaker.shortcut
+        ? [{ hotkey: speaker.shortcut, callback: () => insertAndClose(speaker) }]
+        : [],
+    ),
+    {
+      enabled: open && !settingsOpen,
+      ignoreInputs: false,
+      preventDefault: true,
+      requireReset: true,
+      stopPropagation: true,
+    },
+  );
 
   const openSettings = () => {
     const initialSpeakers = speakers.length
@@ -63,7 +86,7 @@ export function SpeakerMenu({ disabled, onChange, onInsert, speakers }: SpeakerM
       : [{ id: crypto.randomUUID(), name: "", shortcut: SPEAKER_SHORTCUT_OPTIONS[0]?.hotkey ?? null }];
     setDraftSpeakers(initialSpeakers);
     setError(null);
-    setPopoverOpen(false);
+    onOpenChange(false);
     setSettingsOpen(true);
   };
 
@@ -116,15 +139,15 @@ export function SpeakerMenu({ disabled, onChange, onInsert, speakers }: SpeakerM
 
   return (
     <>
-      <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
+      <Popover open={open} onOpenChange={onOpenChange}>
         <PopoverTrigger
           render={
             <Button
               variant="ghost"
               size="icon-sm"
               disabled={disabled}
-              aria-label="Insert speaker"
-              title="Speakers"
+              aria-label={SHORTCUTS.chooseSpeaker.description}
+              title={`${SHORTCUTS.chooseSpeaker.description} (${formatShortcutLabel(SHORTCUTS.chooseSpeaker, modifierKey)})`}
             />
           }
         >
@@ -143,10 +166,7 @@ export function SpeakerMenu({ disabled, onChange, onInsert, speakers }: SpeakerM
                     key={speaker.id}
                     variant="ghost"
                     className="h-8 justify-between px-2 font-normal"
-                    onClick={() => {
-                      onInsert(speaker);
-                      setPopoverOpen(false);
-                    }}
+                    onClick={() => insertAndClose(speaker)}
                   >
                     <span className="truncate">{speaker.name}</span>
                     {shortcut ? <ShortcutKeys shortcut={shortcut} /> : null}
@@ -167,8 +187,8 @@ export function SpeakerMenu({ disabled, onChange, onInsert, speakers }: SpeakerM
       <Dialog open={settingsOpen} onOpenChange={setSettingsOpen}>
         <DialogContent className="sm:max-w-xl">
           <DialogHeader>
-            <DialogTitle>Speaker text and shortcuts</DialogTitle>
-            <DialogDescription>Configured text and shortcuts stay in this browser.</DialogDescription>
+            <DialogTitle>Speaker text and numbers</DialogTitle>
+            <DialogDescription>Configured text and numbers stay in this browser.</DialogDescription>
           </DialogHeader>
 
           <div className="grid max-h-[min(24rem,60vh)] gap-2 overflow-y-auto pr-1">
@@ -189,7 +209,7 @@ export function SpeakerMenu({ disabled, onChange, onInsert, speakers }: SpeakerM
                     })
                   }
                 >
-                  <SelectTrigger aria-label={`Shortcut for ${speaker.name || "speaker"}`} className="col-span-2 row-start-2 w-full sm:col-span-1 sm:col-start-2 sm:row-start-1">
+                  <SelectTrigger aria-label={`Number for ${speaker.name || "speaker"}`} className="col-span-2 row-start-2 w-full sm:col-span-1 sm:col-start-2 sm:row-start-1">
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>

--- a/features/speakers/speaker-settings-store.ts
+++ b/features/speakers/speaker-settings-store.ts
@@ -7,6 +7,7 @@ import {
 } from "@/lib/shortcuts";
 
 const STORAGE_KEY = "transcript-desk:speakers:v1";
+const LEGACY_SPEAKER_SHORTCUT = /^Mod\+Alt\+([1-9])$/;
 
 export type SpeakerDefinition = {
   id: string;
@@ -14,17 +15,28 @@ export type SpeakerDefinition = {
   shortcut: SpeakerShortcut | null;
 };
 
-function isSpeakerDefinition(value: unknown): value is SpeakerDefinition {
+function parseSpeakerDefinition(value: unknown): SpeakerDefinition | null {
   if (!value || typeof value !== "object") {
-    return false;
+    return null;
   }
 
-  const speaker = value as Partial<SpeakerDefinition>;
-  return (
-    typeof speaker.id === "string" &&
-    typeof speaker.name === "string" &&
-    (speaker.shortcut === null || isSpeakerShortcut(speaker.shortcut))
-  );
+  const speaker = value as { id?: unknown; name?: unknown; shortcut?: unknown };
+  if (typeof speaker.id !== "string" || typeof speaker.name !== "string") {
+    return null;
+  }
+
+  if (speaker.shortcut === null || isSpeakerShortcut(speaker.shortcut)) {
+    return { id: speaker.id, name: speaker.name, shortcut: speaker.shortcut };
+  }
+
+  const legacyShortcut =
+    typeof speaker.shortcut === "string"
+      ? LEGACY_SPEAKER_SHORTCUT.exec(speaker.shortcut)?.[1]
+      : undefined;
+
+  return legacyShortcut && isSpeakerShortcut(legacyShortcut)
+    ? { id: speaker.id, name: speaker.name, shortcut: legacyShortcut }
+    : null;
 }
 
 export function loadSpeakerSettings() {
@@ -39,7 +51,12 @@ export function loadSpeakerSettings() {
       return [];
     }
 
-    return parsedValue.filter(isSpeakerDefinition).slice(0, SPEAKER_SHORTCUT_OPTIONS.length);
+    return parsedValue
+      .flatMap((value) => {
+        const speaker = parseSpeakerDefinition(value);
+        return speaker ? [speaker] : [];
+      })
+      .slice(0, SPEAKER_SHORTCUT_OPTIONS.length);
   } catch {
     return [];
   }

--- a/features/workspace/transcript-workspace.tsx
+++ b/features/workspace/transcript-workspace.tsx
@@ -92,6 +92,7 @@ export function TranscriptWorkspace() {
   const [revisions, setRevisions] = useState<TranscriptRevision[]>([]);
   const [savedContent, setSavedContent] = useState("");
   const [savedFileName, setSavedFileName] = useState<string | null>(null);
+  const [speakerMenuOpen, setSpeakerMenuOpen] = useState(false);
   const [speakers, setSpeakers] = useState<SpeakerDefinition[]>([]);
   const hasTranscript = fileName !== null;
   const isDirty = hasTranscript && (content !== savedContent || fileName !== savedFileName);
@@ -138,6 +139,7 @@ export function TranscriptWorkspace() {
     setSavedContent("");
     setFileName(null);
     setSavedFileName(null);
+    setSpeakerMenuOpen(false);
     setEditorHistoryState({ canRedo: false, canUndo: false });
   };
 
@@ -309,6 +311,11 @@ export function TranscriptWorkspace() {
         hotkey: SHORTCUTS.togglePlayback.hotkey,
         callback: () => audioPlayerRef.current?.togglePlayback(),
       },
+      {
+        hotkey: SHORTCUTS.chooseSpeaker.hotkey,
+        callback: () => setSpeakerMenuOpen(true),
+        options: { enabled: hasTranscript },
+      },
       { hotkey: SHORTCUTS.insertTimestamp.hotkey, callback: insertTimestamp },
       {
         hotkey: SHORTCUTS.seekBackFive.hotkey,
@@ -319,11 +326,6 @@ export function TranscriptWorkspace() {
         callback: () => audioPlayerRef.current?.seekBy(5),
       },
       { hotkey: SHORTCUTS.openDocumentation.hotkey, callback: () => router.push("/docs") },
-      ...speakers.flatMap((speaker) =>
-        speaker.shortcut
-          ? [{ hotkey: speaker.shortcut, callback: () => insertSpeaker(speaker) }]
-          : [],
-      ),
     ],
     {
       ignoreInputs: false,
@@ -449,9 +451,11 @@ export function TranscriptWorkspace() {
               />
               <SpeakerMenu
                 disabled={!hasTranscript}
+                open={speakerMenuOpen}
                 speakers={speakers}
                 onChange={updateSpeakers}
                 onInsert={insertSpeaker}
+                onOpenChange={setSpeakerMenuOpen}
               />
               <Tooltip>
                 <TooltipTrigger

--- a/lib/shortcuts.ts
+++ b/lib/shortcuts.ts
@@ -49,6 +49,11 @@ export const SHORTCUTS = {
     group: "playback",
     hotkey: "Mod+Enter",
   },
+  chooseSpeaker: {
+    description: "Choose speaker",
+    group: "editor",
+    hotkey: "Mod+Shift+Enter",
+  },
   seekBackFive: {
     description: "Back five seconds",
     group: "playback",
@@ -95,12 +100,12 @@ export const SHORTCUTS = {
 
 export type ShortcutId = keyof typeof SHORTCUTS;
 
-export type SpeakerShortcut = `Mod+Alt+${1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9}`;
+export type SpeakerShortcut = `${1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9}`;
 
 export const SPEAKER_SHORTCUT_OPTIONS = Array.from({ length: 9 }, (_, index) => {
   const number = index + 1;
   return {
-    hotkey: `Mod+Alt+${number}` as SpeakerShortcut,
+    hotkey: `${number}` as SpeakerShortcut,
     number,
   } satisfies ShortcutDisplay & { hotkey: SpeakerShortcut; number: number };
 });


### PR DESCRIPTION
## Summary

- replace direct speaker modifier-number shortcuts with a two-step speaker picker
- keep play/pause on Ctrl/Cmd+Enter and open speaker selection with Ctrl/Cmd+Shift+Enter
- accept unmodified numbers only while the picker is open
- migrate existing Mod+Alt+number speaker assignments without losing settings
- document the updated workflow

## Why

Windows treats Ctrl+Alt as AltGr on keyboard layouts such as German, so the former shortcut could type characters like ² instead of selecting a speaker. The new flow avoids AltGr, macOS screenshot shortcuts, and browser tab-number shortcuts.

## Validation

- pnpm lint
- pnpm typecheck
- pnpm build

Browser verification intentionally skipped per project preference.